### PR TITLE
Disabled opencl on x264 and ffmpeg build

### DIFF
--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -72,11 +72,11 @@ case $PLATFORM in
         make -j4
         make install
         cd ../$X264
-        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --host=i686-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-opencl --host=i686-linux
         make -j4
         make install
         cd ../ffmpeg-$FFMPEG_VERSION
-        ./configure --prefix=.. --enable-shared --enable-gpl --enable-version3 --enable-runtime-cpudetect --disable-outdev=sdl --enable-libmp3lame --enable-libx264 --cc="gcc -m32" --extra-cflags="-I../include/" --extra-ldflags="-L../lib/ -ldl"
+        ./configure --prefix=.. --enable-shared --enable-gpl --enable-version3 --enable-runtime-cpudetect --disable-opencl --disable-outdev=sdl --enable-libmp3lame --enable-libx264 --cc="gcc -m32" --extra-cflags="-I../include/" --extra-ldflags="-L../lib/ -ldl"
         make -j4
         make install
         ;;
@@ -86,11 +86,11 @@ case $PLATFORM in
         make -j4
         make install
         cd ../$X264
-        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --host=x86_64-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-opencl --host=x86_64-linux
         make -j4
         make install
         cd ../ffmpeg-$FFMPEG_VERSION
-        ./configure --prefix=.. --enable-shared --enable-gpl --enable-version3 --enable-runtime-cpudetect --disable-outdev=sdl --enable-libmp3lame --enable-libx264 --cc="gcc -m64" --extra-cflags="-I../include/" --extra-ldflags="-L../lib/ -ldl"
+        ./configure --prefix=.. --enable-shared --enable-gpl --enable-version3 --enable-runtime-cpudetect --disable-opencl --disable-outdev=sdl --enable-libmp3lame --enable-libx264 --cc="gcc -m64" --extra-cflags="-I../include/" --extra-ldflags="-L../lib/ -ldl"
         make -j4
         make install
         ;;
@@ -100,11 +100,11 @@ case $PLATFORM in
         make -j4
         make install
         cd ../$X264
-        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic
+        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-opencl
         make -j4
         make install
         cd ../ffmpeg-$FFMPEG_VERSION
-        ./configure --prefix=.. --enable-shared --enable-gpl --enable-version3 --enable-runtime-cpudetect --disable-outdev=sdl --enable-libmp3lame --enable-libx264 --extra-cflags="-I../include/" --extra-ldflags="-L../lib/ -Wl,-headerpad_max_install_names -ldl"
+        ./configure --prefix=.. --enable-shared --enable-gpl --enable-version3 --enable-runtime-cpudetect --disable-opencl --disable-outdev=sdl --enable-libmp3lame --enable-libx264 --extra-cflags="-I../include/" --extra-ldflags="-L../lib/ -Wl,-headerpad_max_install_names -ldl"
         make -j4
         make install
         BADPATH=../lib


### PR DESCRIPTION
This modification allows a build to proceed after opencl support has been detected by the x264 build. This is directly related to https://github.com/bytedeco/javacpp-presets/issues/19
