### PR TITLE
Fix creation of OpenCV 3 wrapper on Windows (issue #56).

### DIFF
--- a/opencv/opencv-3.0.0-windows-issue56a.patch
+++ b/opencv/opencv-3.0.0-windows-issue56a.patch
@@ -1,0 +1,11 @@
+--- opencv-3.0.0/modules/objdetect/include/opencv2/objdetect/detection_based_tracker.hpp	2015-06-03 13:21:34.000000000 -0400
++++ opencv-3.0.0-windows/modules/objdetect/include/opencv2/objdetect/detection_based_tracker.hpp	2015-06-22 18:01:13.077857300 -0400
+@@ -58,7 +58,7 @@
+ class CV_EXPORTS DetectionBasedTracker
+ {
+     public:
+-        struct Parameters
++        struct CV_EXPORTS Parameters
+         {
+             int maxTrackLifetime;
+             int minDetectionPeriod; //the minimal time between run of the big object detector (on the whole frame) in ms (1000 mean 1 sec), default=0

--- a/opencv/pom.xml
+++ b/opencv/pom.xml
@@ -48,6 +48,9 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <encoding>ISO-8859-1</encoding>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_calib3d.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_calib3d.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  */
 @Properties(inherit = {opencv_highgui.class, opencv_features2d.class}, value = {
     @Platform(include = {"<opencv2/calib3d/calib3d_c.h>", "<opencv2/calib3d.hpp>"}, link = "opencv_calib3d@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_calib3d300")},
         target = "org.bytedeco.javacpp.opencv_calib3d", helper = "org.bytedeco.javacpp.helper.opencv_calib3d")
 public class opencv_calib3d implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_core.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_core.java
@@ -45,7 +45,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
         "<opencv2/core/utility.hpp>", "<opencv2/core/types_c.h>", "<opencv2/core/core_c.h>", "<opencv2/core/types.hpp>",
         "<opencv2/core.hpp>", "<opencv2/core/operations.hpp>", "<opencv2/core/bufferpool.hpp>", "<opencv2/core/mat.hpp>",
         "<opencv2/core/persistence.hpp>", "<opencv2/core/optim.hpp>", "opencv_adapters.h"}, link = {"opencv_core@.3.0", "opencv_imgproc@.3.0"}),
-    @Platform(value = "windows", define = "_WIN32_WINNT 0x0502", link = "opencv_world300", preload = {"msvcr120", "msvcp120"}),
+    @Platform(value = "windows", define = "_WIN32_WINNT 0x0502", link =  {"opencv_core300", "opencv_imgproc300"}, preload = {"msvcr120", "msvcp120"}),
     @Platform(value = "windows-x86", preloadpath = "C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/redist/x86/Microsoft.VC120.CRT/"),
     @Platform(value = "windows-x86_64", preloadpath = "C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/redist/x64/Microsoft.VC120.CRT/")},
         target = "org.bytedeco.javacpp.opencv_core", helper = "org.bytedeco.javacpp.helper.opencv_core")

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_features2d.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_features2d.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  */
 @Properties(inherit = {opencv_highgui.class, opencv_flann.class, opencv_ml.class}, value = {
     @Platform(include = "<opencv2/features2d.hpp>", link = "opencv_features2d@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_features2d300")},
         target = "org.bytedeco.javacpp.opencv_features2d")
 public class opencv_features2d implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_flann.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_flann.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  */
 @Properties(inherit = opencv_core.class, value = {
     @Platform(include = {"<opencv2/flann/defines.h>", "<opencv2/flann/miniflann.hpp>"}, link = "opencv_flann@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_flann300")},
         target = "org.bytedeco.javacpp.opencv_flann")
 public class opencv_flann implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_highgui.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_highgui.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  */
 @Properties(inherit = {opencv_imgproc.class, opencv_videoio.class}, value = {
     @Platform(include = {"<opencv2/highgui/highgui_c.h>", "<opencv2/highgui.hpp>"}, link = "opencv_highgui@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_highgui300")},
         target = "org.bytedeco.javacpp.opencv_highgui")
 public class opencv_highgui implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_imgcodecs.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_imgcodecs.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  */
 @Properties(inherit = opencv_imgproc.class, value = {
     @Platform(include = {"<opencv2/imgcodecs/imgcodecs_c.h>", "<opencv2/imgcodecs.hpp>"}, link = "opencv_imgcodecs@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_imgcodecs300")},
         target = "org.bytedeco.javacpp.opencv_imgcodecs", helper = "org.bytedeco.javacpp.helper.opencv_imgcodecs")
 public class opencv_imgcodecs implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_imgproc.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_imgproc.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  */
 @Properties(inherit = opencv_core.class, value = {
     @Platform(include = {"<opencv2/imgproc/types_c.h>", "<opencv2/imgproc/imgproc_c.h>", "<opencv2/imgproc.hpp>"}, link = "opencv_imgproc@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_imgproc300")},
         target = "org.bytedeco.javacpp.opencv_imgproc", helper = "org.bytedeco.javacpp.helper.opencv_imgproc")
 public class opencv_imgproc implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_ml.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_ml.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  */
 @Properties(inherit = opencv_core.class, value = {
     @Platform(include = "<opencv2/ml.hpp>", link = "opencv_ml@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_ml300")},
         target = "org.bytedeco.javacpp.opencv_ml")
 public class opencv_ml implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_objdetect.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_objdetect.java
@@ -35,7 +35,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 @Properties(inherit = {opencv_highgui.class, opencv_ml.class}, value = {
     @Platform(include = {"<opencv2/objdetect/objdetect_c.h>", "<opencv2/objdetect.hpp>",
                          "<opencv2/objdetect/detection_based_tracker.hpp>"}, link = "opencv_objdetect@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_objdetect300")},
         target = "org.bytedeco.javacpp.opencv_objdetect", helper = "org.bytedeco.javacpp.helper.opencv_objdetect")
 public class opencv_objdetect implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_photo.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_photo.java
@@ -34,7 +34,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 @Properties(inherit = opencv_imgproc.class, value = {
     @Platform(include = {"<opencv2/photo/photo_c.h>", "<opencv2/photo.hpp>", "<opencv2/photo/cuda.hpp>"},
               link = "opencv_photo@.3.0", preload = "opencv_cuda@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300", preload = "opencv_cuda300")},
+    @Platform(value = "windows", link = "opencv_photo300", preload = "opencv_cuda300")},
         target = "org.bytedeco.javacpp.opencv_photo")
 public class opencv_photo implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_shape.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_shape.java
@@ -36,7 +36,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
     @Platform(include = {
         "<opencv2/shape.hpp>", "<opencv2/shape/emdL1.hpp>", "<opencv2/shape/shape_transformer.hpp>",
         "<opencv2/shape/hist_cost.hpp>", "<opencv2/shape/shape_distance.hpp>"}, link = "opencv_shape@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_shape300")},
         target = "org.bytedeco.javacpp.opencv_shape")
 public class opencv_shape implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_stitching.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_stitching.java
@@ -39,7 +39,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
         "<opencv2/stitching/detail/seam_finders.hpp>", "<opencv2/stitching/detail/blenders.hpp>", "<opencv2/stitching/detail/autocalib.hpp>",
         "<opencv2/stitching/detail/timelapsers.hpp>", "<opencv2/stitching/warpers.hpp>", "<opencv2/stitching.hpp>"},
               link = "opencv_stitching@.3.0", preload = "opencv_cuda@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300", preload = "opencv_cuda300")},
+    @Platform(value = "windows", link = "opencv_stitching300", preload = "opencv_cuda300")},
         target = "org.bytedeco.javacpp.opencv_stitching")
 public class opencv_stitching implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_superres.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_superres.java
@@ -35,7 +35,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 @Properties(inherit = {opencv_video.class, opencv_videoio.class}, value = {
     @Platform(include = {"<opencv2/superres.hpp>", "<opencv2/superres/optical_flow.hpp>"},
               link = "opencv_superres@.3.0", preload = "opencv_cuda@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300", preload = "opencv_cuda300")},
+    @Platform(value = "windows", link = "opencv_superres300", preload = "opencv_cuda300")},
         target = "org.bytedeco.javacpp.opencv_superres")
 public class opencv_superres implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_video.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_video.java
@@ -35,7 +35,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 @Properties(inherit = opencv_imgproc.class, value = {
     @Platform(include = {"<opencv2/video.hpp>", "<opencv2/video/tracking_c.h>", "<opencv2/video/tracking.hpp>",
                          "<opencv2/video/background_segm.hpp>"}, link = "opencv_video@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300")},
+    @Platform(value = "windows", link = "opencv_video300")},
         target = "org.bytedeco.javacpp.opencv_video", helper = "org.bytedeco.javacpp.helper.opencv_video")
 public class opencv_video implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_videoio.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_videoio.java
@@ -37,7 +37,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
     @Platform(value = "android", preload = {
         "native_camera_r2.2.0", "native_camera_r2.3.3", "native_camera_r3.0.1", "native_camera_r4.0.0", "native_camera_r4.0.3",
         "native_camera_r4.1.1", "native_camera_r4.2.0", "native_camera_r4.3.0", "native_camera_r4.4.0"}),
-    @Platform(value = "windows", link = "opencv_world300", preload = {"opencv_ffmpeg300", "opencv_ffmpeg300_64"})},
+    @Platform(value = "windows", link = "opencv_videoio300", preload = {"opencv_ffmpeg300", "opencv_ffmpeg300_64"})},
         target = "org.bytedeco.javacpp.opencv_videoio")
 public class opencv_videoio implements InfoMapper {
     public void map(InfoMap infoMap) {

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_videostab.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_videostab.java
@@ -40,7 +40,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
         "<opencv2/videostab/global_motion.hpp>", "<opencv2/videostab/motion_stabilizing.hpp>", "<opencv2/videostab/inpainting.hpp>",
         "<opencv2/videostab/deblurring.hpp>", "<opencv2/videostab/wobble_suppression.hpp>", "<opencv2/videostab/stabilizer.hpp>",
         "<opencv2/videostab/ring_buffer.hpp>", "<opencv2/videostab.hpp>"}, link = "opencv_videostab@.3.0", preload = "opencv_cuda@.3.0"),
-    @Platform(value = "windows", link = "opencv_world300", preload = "opencv_cuda300")},
+    @Platform(value = "windows", link = "opencv_videostab300", preload = "opencv_cuda300")},
         target = "org.bytedeco.javacpp.opencv_videostab")
 public class opencv_videostab implements InfoMapper {
     public void map(InfoMap infoMap) {


### PR DESCRIPTION
OpenCV is build from source on Windows. Patches are applied to correct issues in OpenCV.

Requires installation of Visual Studio 2013 and Windows version of CMake. The Visual Studio 2013 Community edition works fine too.