### PR TITLE
Incremented openssl dependency version for ffmpeg (second attempt)

### DIFF
--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -28,7 +28,7 @@ else
     LAME=lame-3.99.5
     SPEEX=speex-1.2rc2
     OPENCORE_AMR=opencore-amr-0.1.3
-    OPENSSL=openssl-1.0.2d
+    OPENSSL=openssl-1.0.2e
     OPENH264_VERSION=1.4.0
     X265=x265_1.8
     VPX_VERSION=v1.4.0


### PR DESCRIPTION
openssl 1.0.2d isn't available for download as far as I can see.