### PR TITLE
linux-armhf additions

### DIFF
--- a/caffe/src/main/java/org/bytedeco/javacpp/presets/caffe.java
+++ b/caffe/src/main/java/org/bytedeco/javacpp/presets/caffe.java
@@ -37,7 +37,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  * @author Samuel Audet
  */
 @Properties(inherit = opencv_highgui.class, target = "org.bytedeco.javacpp.caffe", value = {
-    @Platform(value = {"linux", "macosx"}, define = {"NDEBUG", "CPU_ONLY", "SHARED_PTR_NAMESPACE boost", "USE_LEVELDB", "USE_LMDB", "USE_OPENCV"}, include = {"caffe/caffe.hpp",
+    @Platform(value = {"linux-x86", "macosx"}, define = {"NDEBUG", "CPU_ONLY", "SHARED_PTR_NAMESPACE boost", "USE_LEVELDB", "USE_LMDB", "USE_OPENCV"}, include = {"caffe/caffe.hpp",
         "caffe/util/device_alternate.hpp", "google/protobuf/stubs/common.h", "google/protobuf/descriptor.h", "google/protobuf/message_lite.h", "google/protobuf/message.h",
         "caffe/common.hpp", "caffe/proto/caffe.pb.h", "caffe/util/blocking_queue.hpp", "caffe/data_reader.hpp", "caffe/util/math_functions.hpp", "caffe/syncedmem.hpp",
         "caffe/blob.hpp", "caffe/data_transformer.hpp", "caffe/filler.hpp", "caffe/internal_thread.hpp", "caffe/util/hdf5.hpp", "caffe/layers/base_data_layer.hpp", "caffe/layers/data_layer.hpp",

--- a/chilitags/cppbuild.sh
+++ b/chilitags/cppbuild.sh
@@ -40,6 +40,11 @@ case $PLATFORM in
         make -j4
         make install
         ;;
+    linux-armhf)
+        CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
+        make -j4
+        make install
+        ;;
     macosx-*)
         CXX="clang++ -fPIC" $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
         make -j4

--- a/cuda/cppbuild.sh
+++ b/cuda/cppbuild.sh
@@ -8,7 +8,7 @@ if [[ -z "$PLATFORM" ]]; then
 fi
 
 case $PLATFORM in
-    linux-*)
+    linux-x86*)
         if [[ ! -d "/usr/local/cuda/" ]]; then
             echo "Please install CUDA under the default installation directory"
             exit 1

--- a/cuda/src/main/java/org/bytedeco/javacpp/presets/cuda.java
+++ b/cuda/src/main/java/org/bytedeco/javacpp/presets/cuda.java
@@ -32,7 +32,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  *
  * @author Samuel Audet
  */
-@Properties(names = {"linux-x86_64", "linux-arm", "linux-arm64", "linux-ppc64le", "macosx-x86_64", "windows-x86_64"}, value = {
+@Properties(names = {"linux-x86_64", "linux-arm64", "linux-ppc64le", "macosx-x86_64", "windows-x86_64"}, value = {
     @Platform(include = {"<cuda.h>", "<host_defines.h>", "<device_types.h>", "<driver_types.h>", "<surface_types.h>", "<texture_types.h>",
                          "<vector_types.h>", "<builtin_types.h>", "<cuda_runtime_api.h>", "<driver_functions.h>", "<vector_functions.h>",
                        /*"<cuda_device_runtime_api.h>", <cuda_runtime.h>"*/ "<cuComplex.h>", "<cuda_fp16.h>", "<library_types.h>"},

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -270,7 +270,7 @@ case $PLATFORM in
         make -j $MAKEJ
         make install
         cd ../$OPENSSL
-        ./Configure linux-armv4:arm-linux-gnueabihf-gcc -march=armv6 -mfpu=vfp -mfloat-abi=hard -fPIC no-shared --prefix=$INSTALL_PATH
+        ./Configure linux-armv4 -march=armv6 -mfpu=vfp -mfloat-abi=hard -fPIC no-shared --prefix=$INSTALL_PATH
         make # fails with -j > 1
         make install
         cd ../openh264-$OPENH264_VERSION
@@ -280,7 +280,7 @@ case $PLATFORM in
         make -j $MAKEJ
         make install
         cd ../$X265
-        $CMAKE -DENABLE_CLI=OFF -DENABLE_SHARED=OFF -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=armv6 -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_C_COMPILER=/usr/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/usr/bin/arm-linux-gnueabihf-g++ -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_STRIP=/usr/bin/arm-linux-gnueabihf-strip -DCMAKE_FIND_ROOT_PATH=/usr/arm-linux-gnueabihf -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. source
+        $CMAKE -DENABLE_CLI=OFF -DENABLE_SHARED=OFF -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_SYSTEM_PROCESSOR=armv6 -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_C_COMPILER=/rpxc/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/rpxc/bin/arm-linux-gnueabihf-g++ -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_STRIP=/rpxc/bin/arm-linux-gnueabihf-strip -DCMAKE_FIND_ROOT_PATH=/rpxc/arm-linux-gnueabihf -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. source
         make -j $MAKEJ
         make install
         cd ../libvpx-$VPX_VERSION
@@ -289,7 +289,7 @@ case $PLATFORM in
         make install
         cd ../ffmpeg-$FFMPEG_VERSION
         [[ $ENABLE =~ "--enable-gpl" ]] && X11GRAB="--enable-x11grab" || X11GRAB=
-        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --cc="arm-linux-gnueabihf-gcc" --extra-cflags="-I../include/" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -ldl" --enable-cross-compile --arch=armhf --target-os=linux --cross-prefix="arm-linux-gnueabihf-" --pkg-config-flags="--static" --pkg-config="pkg-config --static"
+        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --cc="arm-linux-gnueabihf-gcc" --extra-cflags="-I/opt/additionalInclude/ -I../include/" --extra-ldflags="-L../lib/ -L/opt/additionalLib" --extra-libs="-lstdc++ -ldl -lasound" --enable-cross-compile --arch=armhf --target-os=linux --cross-prefix="arm-linux-gnueabihf-" --pkg-config-flags="--static" --pkg-config="pkg-config --static"
         make -j $MAKEJ
         make install
         ;;
@@ -463,3 +463,4 @@ case $PLATFORM in
 esac
 
 cd ../..
+

--- a/fftw/cppbuild.sh
+++ b/fftw/cppbuild.sh
@@ -81,6 +81,14 @@ case $PLATFORM in
         make -j $MAKEJ
         make install-strip
         ;;
+    linux-armhf)
+        ./configure --prefix=$INSTALL_PATH --disable-shared --with-pic --host=arm-linux-gnueabihf 
+        make -j $MAKEJ
+        make install-strip
+        ./configure --prefix=$INSTALL_PATH --disable-shared --with-pic --host=arm-linux-gnueabihf --enable-float
+        make -j $MAKEJ
+        make install-strip
+	;;
     macosx-*)
         patch -Np1 < ../../../fftw-$FFTW_VERSION-macosx.patch
         ./configure --prefix=$INSTALL_PATH --enable-shared --enable-threads --with-combined-threads --enable-sse2

--- a/gsl/cppbuild.sh
+++ b/gsl/cppbuild.sh
@@ -59,6 +59,11 @@ case $PLATFORM in
         make -j $MAKEJ
         make install-strip
         ;;
+    linux-armhf)
+        ./configure --prefix=$INSTALL_PATH --disable-shared --with-pic --host=arm-linux-gnueabihf
+        make -j $MAKEJ
+        make install-strip
+	;;
     macosx-*)
         patch -Np1 < ../../../gsl-$GSL_VERSION-macosx.patch
         ./configure --prefix=$INSTALL_PATH

--- a/leptonica/cppbuild.sh
+++ b/leptonica/cppbuild.sh
@@ -10,14 +10,14 @@ fi
 ZLIB=zlib-1.2.8
 GIFLIB=giflib-5.1.1
 LIBJPEG=libjpeg-turbo-1.4.1
-LIBPNG=libpng-1.6.22
+LIBPNG=libpng-1.6.24
 LIBTIFF=tiff-4.0.4
 LIBWEBP=libwebp-0.4.3
 LEPTONICA_VERSION=1.73
 download http://zlib.net/$ZLIB.tar.gz $ZLIB.tar.gz
 download http://downloads.sourceforge.net/project/giflib/$GIFLIB.tar.gz $GIFLIB.tar.gz
 download http://downloads.sourceforge.net/project/libjpeg-turbo/1.4.1/$LIBJPEG.tar.gz $LIBJPEG.tar.gz
-download http://downloads.sourceforge.net/project/libpng/libpng16/1.6.22/$LIBPNG.tar.gz $LIBPNG.tar.gz
+download http://downloads.sourceforge.net/project/libpng/libpng16/1.6.24/$LIBPNG.tar.gz $LIBPNG.tar.gz
 download http://download.osgeo.org/libtiff/$LIBTIFF.tar.gz $LIBTIFF.tar.gz
 download http://downloads.webmproject.org/releases/webp/$LIBWEBP.tar.gz $LIBWEBP.tar.gz
 download http://www.leptonica.org/source/leptonica-$LEPTONICA_VERSION.tar.gz leptonica-$LEPTONICA_VERSION.tar.gz
@@ -181,6 +181,41 @@ case $PLATFORM in
         make install
         cd ../leptonica-$LEPTONICA_VERSION
         ./configure --prefix=$INSTALL_PATH CFLAGS="-pthread -I$INSTALL_PATH/include/" LDFLAGS="-L$INSTALL_PATH/lib/" --disable-programs
+        make -j $MAKEJ
+        make install-strip
+        ;;
+    linux-armhf)
+        export CFLAGS="-march=armv6 -marm -mfpu=vfp -mfloat-abi=hard -I$INSTALL_PATH/include/"
+        export CXXFLAGS="$CFLAGS"
+        export CPPFLAGS="$CFLAGS"
+        export CC="arm-linux-gnueabihf-gcc -fPIC"
+        cd $ZLIB
+        CC="arm-linux-gnueabihf-gcc -fPIC" ./configure --prefix=$INSTALL_PATH --static
+        make -j $MAKEJ
+        make install
+        cd ../$GIFLIB
+        CC="arm-linux-gnueabihf-gcc -fPIC" ./configure --prefix=$INSTALL_PATH --host=arm-linux-gnueabihf --disable-shared
+	#./configure --prefix=$INSTALL_PATH --disable-shared --host=arm-linux-gnueabihf
+        make -j $MAKEJ
+        make install
+        cd ../$LIBJPEG
+	./configure --prefix=$INSTALL_PATH --disable-shared --with-pic --host=arm-linux-gnueabihf
+        make -j $MAKEJ
+        make install
+        cd ../$LIBPNG
+	CC="arm-linux-gnueabihf-gcc -fPIC" ./configure --prefix=$INSTALL_PATH CFLAGS="-pthread -I$INSTALL_PATH/include/" LDFLAGS="-L$INSTALL_PATH/lib/" --disable-shared --with-pic --host=arm-linux-gnueabihf
+        make -j $MAKEJ
+        make install
+        cd ../$LIBTIFF
+	./configure --prefix=$INSTALL_PATH --disable-shared --with-pic --disable-lzma --host=arm-linux-gnueabihf
+        make -j $MAKEJ
+        make install
+        cd ../$LIBWEBP
+	./configure --prefix=$INSTALL_PATH --disable-shared --with-pic --host=arm-linux-gnueabihf
+        make -j $MAKEJ
+        make install
+        cd ../leptonica-$LEPTONICA_VERSION
+        CC="arm-linux-gnueabihf-gcc -fPIC" ./configure --prefix=$INSTALL_PATH CFLAGS="-pthread -I$INSTALL_PATH/include/" LDFLAGS="-L$INSTALL_PATH/lib/"  --host=arm-linux-gnueabihf --disable-programs
         make -j $MAKEJ
         make install-strip
         ;;

--- a/llvm/cppbuild.sh
+++ b/llvm/cppbuild.sh
@@ -16,6 +16,10 @@ case $PLATFORM in
         export CC="clang -m64"
         export CXX="clang++ -m64"
         ;;
+    linux-armhf)
+	export CC_FLAGS="clang -target arm -march=armv7 -mfloat-abi=hard"
+	export CXX_FLAGS="-target arm -march=armv7 -mfloat-abi=hard"
+        ;;
     macosx-*)
         ;;
     *)

--- a/llvm/src/main/java/org/bytedeco/javacpp/presets/LLVM.java
+++ b/llvm/src/main/java/org/bytedeco/javacpp/presets/LLVM.java
@@ -25,7 +25,7 @@ package org.bytedeco.javacpp.presets;
 import org.bytedeco.javacpp.annotation.*;
 import org.bytedeco.javacpp.tools.*;
 
-@Properties(target = "org.bytedeco.javacpp.LLVM", value = @Platform(not = {"android", "windows"}, define = {"__STDC_LIMIT_MACROS", "__STDC_CONSTANT_MACROS"},
+@Properties(target = "org.bytedeco.javacpp.LLVM", value = @Platform(not = {"android", "windows", "linux-armhf"}, define = {"__STDC_LIMIT_MACROS", "__STDC_CONSTANT_MACROS"},
     include = {"<llvm-c/Types.h>", "<llvm-c/Support.h>", "<llvm-c/Core.h>", "<llvm-c/Analysis.h>", "<llvm-c/BitReader.h>", "<llvm-c/BitWriter.h>",
                "<llvm-c/Disassembler.h>", "<llvm-c/Initialization.h>", "<llvm-c/IRReader.h>", "<llvm-c/Linker.h>", "<llvm-c/LinkTimeOptimizer.h>",
                "<llvm-c/lto.h>", "<llvm-c/Object.h>", "<llvm-c/Target.h>", "<llvm-c/TargetMachine.h>", "<llvm-c/ExecutionEngine.h>",

--- a/mxnet/src/main/java/org/bytedeco/javacpp/presets/mxnet.java
+++ b/mxnet/src/main/java/org/bytedeco/javacpp/presets/mxnet.java
@@ -37,7 +37,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  * @author Samuel Audet
  */
 @Properties(inherit = opencv_highgui.class, target = "org.bytedeco.javacpp.mxnet", value = {
-    @Platform(value = {"linux", "macosx"}, compiler = "cpp11", define = {"DMLC_USE_CXX11 1", "MSHADOW_USE_CBLAS 1", "MSHADOW_IN_CXX11 1"},
+    @Platform(value = {"linux-x86", "macosx"}, compiler = "cpp11", define = {"DMLC_USE_CXX11 1", "MSHADOW_USE_CBLAS 1", "MSHADOW_IN_CXX11 1"},
         include = {"mxnet/c_api.h", "mxnet/c_predict_api.h", /*"dmlc/base.h", "dmlc/io.h", "dmlc/logging.h", "dmlc/type_traits.h",
                    "dmlc/parameter.h", "mshadow/base.h", "mshadow/expression.h", "mshadow/tensor.h", "mxnet/base.h",*/},
         link = "mxnet", includepath = {"/usr/local/cuda/include/",

--- a/openblas/cppbuild.sh
+++ b/openblas/cppbuild.sh
@@ -67,6 +67,12 @@ case $PLATFORM in
         export BINARY=64
         export TARGET=POWER8
         ;;
+    linux-armhf)
+        export CC="arm-linux-gnueabihf-gcc"
+        export FC="arm-linux-gnueabihf-gfortran"
+        export BINARY=32
+        export TARGET=ARMV6
+        ;;
     macosx-*)
         export CC="gcc"
         export FC="gfortran"

--- a/tensorflow/src/main/java/org/bytedeco/javacpp/presets/tensorflow.java
+++ b/tensorflow/src/main/java/org/bytedeco/javacpp/presets/tensorflow.java
@@ -45,7 +45,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
  *
  * @author Samuel Audet
  */
-@Properties(value = @Platform(value = {"linux", "macosx"}, compiler = "cpp11", define = "NDEBUG", include = {
+@Properties(value = @Platform(value = {"linux-x86", "macosx"}, compiler = "cpp11", define = "NDEBUG", include = {
         "tensorflow/core/platform/default/integral_types.h", "tensorflow/core/framework/numeric_types.h", "tensorflow/core/platform/init_main.h",
         /* "tensorflow/core/platform/default/mutex.h", "tensorflow/core/lib/core/refcount.h", "tensorflow/core/lib/gtl/array_slice.h",
         "tensorflow/core/lib/core/stringpiece.h", */ "tensorflow/core/platform/types.h", "tensorflow/core/platform/mutex.h",

--- a/tesseract/cppbuild.sh
+++ b/tesseract/cppbuild.sh
@@ -38,6 +38,11 @@ case $PLATFORM in
         make -j $MAKEJ
         make install-strip
         ;;
+    linux-armhf)
+        ./configure --prefix=$INSTALL_PATH --host=arm-linux-gnueabihf CC="arm-linux-gnueabihf-gcc" CXX="arm-linux-gnueabihf-g++" LIBLEPT_HEADERSDIR="$INSTALL_PATH/../../../leptonica/cppbuild/$PLATFORM/include/" CPPFLAGS="-I$INSTALL_PATH/../../../leptonica/cppbuild/$PLATFORM/include/" LDFLAGS="-L$INSTALL_PATH/../../../leptonica/cppbuild/$PLATFORM/lib/"
+        make -j $MAKEJ
+        make install-strip
+        ;;
     linux-x86_64)
         ./configure --prefix=$INSTALL_PATH CC="$OLDCC -m64" CXX="$OLDCXX -m64" LIBLEPT_HEADERSDIR="$INSTALL_PATH/../../../leptonica/cppbuild/$PLATFORM/include/" CPPFLAGS="-I$INSTALL_PATH/../../../leptonica/cppbuild/$PLATFORM/include/" LDFLAGS="-L$INSTALL_PATH/../../../leptonica/cppbuild/$PLATFORM/lib/"
         make -j $MAKEJ


### PR DESCRIPTION
Hopefully these fix the lot for arm-hf, seems to build OK with:
mvn install -Djavacpp.platform=linux-armhf -Dplatform=linux-armhf -Dplatform.compiler=arm-linux-gnueabihf-g++ -Djavacpp.platform.compiler=arm-linux-gnueabihf-g++

to build all the presets. Only bit to check, I modified cuda and took out the linux-arm - I'm not sure that would be used? Otherwise needs some way to not try and build it for linux-armhf?