### PR TITLE
update maven plugins for openjdk9 + arm support for native or crosscompile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.0.2</version>
         <executions>
           <execution>
             <id>default-jar</id>
@@ -278,7 +278,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-source</id>
@@ -290,7 +290,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>2.10.4</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
This seems to get things working with openjdk 9 (some reported issues on earlier maven plugins), and was just ffmpeg that needed a small rework of cppbuild.sh to run natively on arm or in a cross compile setup. Natively on the pi needs platform linux-armhf specified, and openblas is really hard on the memory, seems a better chance if doc building is skipped with -Dmaven.javadoc.skip=true