### PR TITLE
Adding support for opencv text module

### DIFF
--- a/opencv/cppbuild.sh
+++ b/opencv/cppbuild.sh
@@ -17,7 +17,7 @@ tar -xzvf ../opencv-$OPENCV_VERSION.tar.gz
 tar -xzvf ../opencv_contrib-$OPENCV_VERSION.tar.gz
 cd opencv-$OPENCV_VERSION
 
-BUILD_CONTRIB_X="-DBUILD_opencv_stereo=OFF -DBUILD_opencv_plot=OFF -DBUILD_opencv_fuzzy=OFF -DBUILD_opencv_aruco=OFF -DBUILD_opencv_adas=OFF -DBUILD_opencv_bgsegm=OFF -DBUILD_opencv_bioinspired=ON -DBUILD_opencv_ccalib=OFF -DBUILD_opencv_datasets=OFF -DBUILD_opencv_dnn=ON -DBUILD_opencv_dpm=OFF -DBUILD_opencv_face=ON -DBUILD_opencv_latentsvm=OFF -DBUILD_opencv_line_descriptor=OFF -DBUILD_opencv_matlab=OFF -DBUILD_opencv_optflow=ON -DBUILD_opencv_reg=OFF -DBUILD_opencv_rgbd=OFF -DBUILD_opencv_saliency=OFF -DBUILD_opencv_surface_matching=OFF -DBUILD_opencv_text=OFF -DBUILD_opencv_tracking=OFF -DBUILD_opencv_xfeatures2d=ON -DBUILD_opencv_ximgproc=ON -DBUILD_opencv_xobjdetect=OFF -DBUILD_opencv_xphoto=OFF"
+BUILD_CONTRIB_X="-DBUILD_opencv_stereo=OFF -DBUILD_opencv_plot=OFF -DBUILD_opencv_fuzzy=OFF -DBUILD_opencv_aruco=OFF -DBUILD_opencv_adas=OFF -DBUILD_opencv_bgsegm=OFF -DBUILD_opencv_bioinspired=ON -DBUILD_opencv_ccalib=OFF -DBUILD_opencv_datasets=OFF -DBUILD_opencv_dnn=ON -DBUILD_opencv_dpm=OFF -DBUILD_opencv_face=ON -DBUILD_opencv_latentsvm=OFF -DBUILD_opencv_line_descriptor=OFF -DBUILD_opencv_matlab=OFF -DBUILD_opencv_optflow=ON -DBUILD_opencv_reg=OFF -DBUILD_opencv_rgbd=OFF -DBUILD_opencv_saliency=OFF -DBUILD_opencv_surface_matching=OFF -DBUILD_opencv_text=ON -DBUILD_opencv_tracking=OFF -DBUILD_opencv_xfeatures2d=ON -DBUILD_opencv_ximgproc=ON -DBUILD_opencv_xobjdetect=OFF -DBUILD_opencv_xphoto=OFF"
 
 case $PLATFORM in
     android-arm)

--- a/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_text.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/presets/opencv_text.java
@@ -1,0 +1,32 @@
+package org.bytedeco.javacpp.presets;
+
+import org.bytedeco.javacpp.annotation.Platform;
+import org.bytedeco.javacpp.annotation.Properties;
+import org.bytedeco.javacpp.tools.Info;
+import org.bytedeco.javacpp.tools.InfoMap;
+import org.bytedeco.javacpp.tools.InfoMapper;
+
+/**
+ * Wrapper for OpenCV module text, part of OpenCV_Contrib.
+ *
+ * @author Bram Biesbrouck
+ */
+@Properties(inherit = {opencv_highgui.class, opencv_ml.class}, value = {
+    @Platform(include = {"<opencv2/text.hpp>", "<opencv2/text/erfilter.hpp>", "<opencv2/text/ocr.hpp>", "opencv_adapters.h"},
+              link = "opencv_text@.3.1"),
+    @Platform(value = "windows", link = "opencv_text310")},
+              target = "org.bytedeco.javacpp.opencv_text")
+public class opencv_text implements InfoMapper {
+    public void map(InfoMap infoMap) {
+	
+	infoMap.put(new Info("std::deque<int>").pointerTypes("IntDeque").define());
+	infoMap.put(new Info("std::vector<cv::text::ERStat>").pointerTypes("ERStatVector").define());
+	infoMap.put(new Info("std::vector<std::vector<cv::text::ERStat> >").pointerTypes("ERStatVectorVector").define());
+	infoMap.put(new Info("std::vector<double>").pointerTypes("DoubleVector").define());
+	infoMap.put(new Info("std::vector<std::string>").pointerTypes("StdStringVector").define());
+	
+	infoMap.put(new Info("std::vector<cv::Vec2i>").pointerTypes("PointVector").cast());
+	infoMap.put(new Info("std::vector<std::vector<cv::Vec2i> >").pointerTypes("PointVectorVector").cast());
+	
+    }
+}


### PR DESCRIPTION
Changed the opencv build script to include the text module and added a new opencv_text preset.
Tested (only) on linux-x86_64 (Ubuntu Trusty).