### PR TITLE
increase heap for javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,8 @@
               <goal>jar</goal>
             </goals>
             <configuration>
+              <minmemory>128m</minmemory>
+              <maxmemory>1024m</maxmemory>
               <links>
                 <link>http://bytedeco.org/javacpp/apidocs/</link>
               </links>


### PR DESCRIPTION
Looks like openblas javadocs needs somewhere over 512MB mem to build, so liable to crash using default heap size on platforms with 2GB or less mem. Should fix native pi arm builds.