### PR TITLE
fix issue with flandmark androidarm build

### DIFF
--- a/chilitags/cppbuild.sh
+++ b/chilitags/cppbuild.sh
@@ -21,12 +21,12 @@ OPENCV_PATH=$INSTALL_PATH/../../../opencv/cppbuild/$PLATFORM/
 
 case $PLATFORM in
     android-arm)
-        ANDROID_STANDALONE_TOOLCHAIN=$ANDROID_NDK ANDROID_NATIVE_API_LEVEL=14 ANDROID_ABI=armeabi-v7a ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-4.9 $CMAKE -DANDROID_ABI=armeabi-v7a -DCMAKE_TOOLCHAIN_FILE=$OPENCV_PATH/opencv-3.2.0/platforms/android/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/
+        ANDROID_STANDALONE_TOOLCHAIN=$ANDROID_NDK ANDROID_NATIVE_API_LEVEL=14 ANDROID_ABI=armeabi-v7a ANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-4.9 $CMAKE -DANDROID_ABI=armeabi-v7a -DCMAKE_TOOLCHAIN_FILE=$OPENCV_PATH/opencv-3.2.0/platforms/android/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/abi-armeabi-v7a/
         make -j4
         make install
         ;;
     android-x86)
-        ANDROID_STANDALONE_TOOLCHAIN=$ANDROID_NDK ANDROID_NATIVE_API_LEVEL=14 ANDROID_ABI=x86 ANDROID_TOOLCHAIN_NAME=x86-4.9 $CMAKE -DANDROID_ABI=x86 -DCMAKE_TOOLCHAIN_FILE=$OPENCV_PATH/opencv-3.2.0/platforms/android/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/
+        ANDROID_STANDALONE_TOOLCHAIN=$ANDROID_NDK ANDROID_NATIVE_API_LEVEL=14 ANDROID_ABI=x86 ANDROID_TOOLCHAIN_NAME=x86-4.9 $CMAKE -DANDROID_ABI=x86 -DCMAKE_TOOLCHAIN_FILE=$OPENCV_PATH/opencv-3.2.0/platforms/android/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/abi-x86/
         make -j4
         make install
         ;;

--- a/cppbuild.sh
+++ b/cppbuild.sh
@@ -94,7 +94,7 @@ function download {
         curl -L "$1" -o "$TOP_PATH/downloads/$2" --fail
         DOWNLOADSTATUS=$?
         if [ "$DOWNLOADSTATUS" -eq 28 ]
-	then
+        then
 		echo "Download timed out, waiting 5 minutes then trying again"
 		rm "$TOP_PATH/downloads/$2"
 		sleep 600
@@ -106,11 +106,11 @@ function download {
 			exit 1
     		fi
         elif [ "$DOWNLOADSTATUS" -ne 0 ]
-	then
+        then
 		echo "File could not be downloaded!"
 		rm "$TOP_PATH/downloads/$2"
 		exit 1
-    	fi
+        fi
     fi
     ln -sf "$TOP_PATH/downloads/$2" "$2"
 }

--- a/cppbuild.sh
+++ b/cppbuild.sh
@@ -91,7 +91,26 @@ function download {
     mkdir -p "$TOP_PATH/downloads"
     if [[ ! -e "$TOP_PATH/downloads/$2" ]]; then
         echo "Downloading $1"
-        curl -L "$1" -o "$TOP_PATH/downloads/$2"
+        curl -L "$1" -o "$TOP_PATH/downloads/$2" --fail
+        DOWNLOADSTATUS=$?
+        if [ "$DOWNLOADSTATUS" -eq 28 ]
+	then
+		echo "Download timed out, waiting 5 minutes then trying again"
+		rm "$TOP_PATH/downloads/$2"
+		sleep 600
+        	curl -L "$1" -o "$TOP_PATH/downloads/$2" --fail
+        	if [ $? -ne 0 ]
+        	then
+			echo "File still could not be downloaded!"
+			rm "$TOP_PATH/downloads/$2"
+			exit 1
+    		fi
+        elif [ "$DOWNLOADSTATUS" -ne 0 ]
+	then
+		echo "File could not be downloaded!"
+		rm "$TOP_PATH/downloads/$2"
+		exit 1
+    	fi
     fi
     ln -sf "$TOP_PATH/downloads/$2" "$2"
 }

--- a/flandmark/cppbuild.sh
+++ b/flandmark/cppbuild.sh
@@ -21,7 +21,7 @@ OPENCV_PATH=$INSTALL_PATH/../../../opencv/cppbuild/$PLATFORM/
 
 case $PLATFORM in
     android-arm)
-        $CMAKE -DCMAKE_TOOLCHAIN_FILE=$INSTALL_PATH/../../android-arm.cmake -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/ -DANDROID_NDK_ABI_NAME=armeabi_v7a
+        $CMAKE -DCMAKE_TOOLCHAIN_FILE=$INSTALL_PATH/../../android-arm.cmake -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/opencv-3.2.0 -DANDROID_NDK_ABI_NAME=armeabi_v7a
         make -j4 flandmark_static
         cp libflandmark/*.h ../include
         cp libflandmark/*.a ../lib

--- a/flandmark/cppbuild.sh
+++ b/flandmark/cppbuild.sh
@@ -21,13 +21,13 @@ OPENCV_PATH=$INSTALL_PATH/../../../opencv/cppbuild/$PLATFORM/
 
 case $PLATFORM in
     android-arm)
-        $CMAKE -DCMAKE_TOOLCHAIN_FILE=$INSTALL_PATH/../../android-arm.cmake -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/opencv-3.2.0 -DANDROID_NDK_ABI_NAME=armeabi_v7a
+        $CMAKE -DCMAKE_TOOLCHAIN_FILE=$INSTALL_PATH/../../android-arm.cmake -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/abi-armeabi-v7a/
         make -j4 flandmark_static
         cp libflandmark/*.h ../include
         cp libflandmark/*.a ../lib
         ;;
     android-x86)
-        $CMAKE -DCMAKE_TOOLCHAIN_FILE=$INSTALL_PATH/../../android-x86.cmake -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/ -DANDROID_NDK_ABI_NAME=x86
+        $CMAKE -DCMAKE_TOOLCHAIN_FILE=$INSTALL_PATH/../../android-x86.cmake -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/sdk/native/jni/abi-x86/ 
         make -j4 flandmark_static
         cp libflandmark/*.h ../include
         cp libflandmark/*.a ../lib


### PR DESCRIPTION
Jenkins is failing to build this, wonder if something to do with new opencv version or update to flandmark maybe. 

Previously when it was building OK it looked like this
rebuilt/linux-x86_64/bin/arm-linux-androideabi-gcc
-- Check for working C compiler: /var/lib/jenkins/Android/android-ndk//toolchains/arm-linux-androideabi-4.9/p
rebuilt/linux-x86_64/bin/arm-linux-androideabi-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /var/lib/jenkins/Android/android-ndk//toolchains/arm-linux-androideabi-4.9
/prebuilt/linux-x86_64/bin/arm-linux-androideabi-g++
-- Check for working CXX compiler: /var/lib/jenkins/Android/android-ndk//toolchains/arm-linux-androideabi-4.9
/prebuilt/linux-x86_64/bin/arm-linux-androideabi-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /var/lib/jenkins/workspace/Presets-Android/javacpp-presets/flandmark/cppbuild/android-arm/flandmark-master

Changing the opencv dir, it now builds OK with output looking like this
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /var/lib/jenkins/Android/android-ndk//toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-g++
-- Check for working CXX compiler: /var/lib/jenkins/Android/android-ndk//toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenCV: /var/lib/jenkins/workspace/Presets-AndroidArm/javacpp-presets/opencv/cppbuild/android-arm/opencv-3.2.0 (found version "3.2.0") 
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    ANDROID_NDK_ABI_NAME


-- Build files have been written to: /var/lib/jenkins/workspace/Presets-AndroidArm/javacpp-presets/flandmark/cppbuild/android-arm/flandmark-master
++ make -j4 flandmark_static
Scanning dependencies of target flandmark_static


So seems to more strongly mention finding opencv, but doesn't seem happy about the android abi flag. 

If that seems OK to you, then probably worth pulling this to get it building again
