### PR TITLE
Add tensorflow with gpu support for windows

### DIFF
--- a/tensorflow/README.md
+++ b/tensorflow/README.md
@@ -60,6 +60,12 @@ We can use [Maven 3](http://maven.apache.org/) to download and install automatic
             <version>1.8.0-1.4.2-SNAPSHOT</version>
             <classifier>macosx-x86_64-gpu</classifier>
         </dependency>
+        <dependency>
+            <groupId>org.bytedeco.javacpp-presets</groupId>
+            <artifactId>tensorflow</artifactId>
+            <version>1.8.0-1.4.2-SNAPSHOT</version>
+            <classifier>windows-x86_64-gpu</classifier>
+        </dependency>
 
     </dependencies>
 </project>

--- a/tensorflow/cppbuild.sh
+++ b/tensorflow/cppbuild.sh
@@ -145,7 +145,9 @@ case $PLATFORM in
         mkdir -p ../build
         cd ../build
         "$CMAKE" -A x64 -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE="C:/Python27/python.exe" -Dtensorflow_BUILD_PYTHON_BINDINGS=OFF -Dtensorflow_BUILD_SHARED_LIB=ON -Dtensorflow_WIN_CPU_SIMD_OPTIONS=/arch:AVX -G"Visual Studio 14" $CMAKE_GPU_FLAGS -DCUDNN_HOME="$CUDA_PATH" ../tensorflow-$TENSORFLOW_VERSION/tensorflow/contrib/cmake
-        MSBuild.exe //p:Configuration=Release /maxcpucount:$MAKEJ tf_core_gpu_kernels.vcxproj
+        if [[ "$EXTENSION" == *gpu ]]; then
+            MSBuild.exe //p:Configuration=Release /maxcpucount:$MAKEJ tf_core_gpu_kernels.vcxproj
+        fi
         MSBuild.exe //p:Configuration=Release /maxcpucount:$MAKEJ tensorflow_static.vcxproj
         cd ../tensorflow-$TENSORFLOW_VERSION
         ;;

--- a/tensorflow/cppbuild.sh
+++ b/tensorflow/cppbuild.sh
@@ -69,7 +69,7 @@ if [[ "$EXTENSION" == *gpu ]]; then
     export TF_NEED_CUDA=1
     export TF_NEED_TENSORRT=1
     export GPU_FLAGS="--config=cuda"
-    export CMAKE_GPU_FLAGS="-Dtensorflow_ENABLE_GPU=ON -Dtensorflow_CUDA_VERSION=$TF_CUDA_VERSION -Dtensorflow_CUDNN_VERSION=$TF_CUDNN_VERSION -DCUDNN_HOME=$CUDNN_INSTALL_PATH" 
+    export CMAKE_GPU_FLAGS="-Dtensorflow_ENABLE_GPU=ON -Dtensorflow_CUDA_VERSION=$TF_CUDA_VERSION -Dtensorflow_CUDNN_VERSION=$TF_CUDNN_VERSION"
 fi
 
 if [[ "$TF_NEED_CUDA" == 0 ]] || [[ ! -d "$TENSORRT_INSTALL_PATH" ]]; then
@@ -139,16 +139,15 @@ case $PLATFORM in
         export PATH=$DYLD_LIBRARY_PATH:$PATH
         patch -Np1 < ../../../tensorflow-macosx.patch
         ;;
-    windows-x86_64)	
-		# help cmake's findCuda-method to find the right cuda version
-		export CUDA_PATH=$CUDA_TOOLKIT_PATH
-	
-        mkdir -p tensorflow/contrib/cmake/build
-        cd tensorflow/contrib/cmake/build
-        "$CMAKE" -A x64 -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE="C:/Python27/python.exe" -Dtensorflow_BUILD_PYTHON_BINDINGS=OFF -Dtensorflow_BUILD_SHARED_LIB=ON -Dtensorflow_WIN_CPU_SIMD_OPTIONS=/arch:AVX -G"Visual Studio 14" $CMAKE_GPU_FLAGS ..
-		MSBuild.exe //p:Configuration=Release /maxcpucount:$MAKEJ tf_core_gpu_kernels.vcxproj
-        MSBuild.exe  //p:Configuration=Release /maxcpucount:$MAKEJ tensorflow_static.vcxproj
-        cd ../../../..
+    windows-x86_64)
+        # help cmake's findCuda-method to find the right cuda version
+        export CUDA_PATH="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v$TF_CUDA_VERSION"
+        mkdir -p ../build
+        cd ../build
+        "$CMAKE" -A x64 -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE="C:/Python27/python.exe" -Dtensorflow_BUILD_PYTHON_BINDINGS=OFF -Dtensorflow_BUILD_SHARED_LIB=ON -Dtensorflow_WIN_CPU_SIMD_OPTIONS=/arch:AVX -G"Visual Studio 14" $CMAKE_GPU_FLAGS -DCUDNN_HOME="$CUDA_PATH" ../tensorflow-$TENSORFLOW_VERSION/tensorflow/contrib/cmake
+        MSBuild.exe //p:Configuration=Release /maxcpucount:$MAKEJ tf_core_gpu_kernels.vcxproj
+        MSBuild.exe //p:Configuration=Release /maxcpucount:$MAKEJ tensorflow_static.vcxproj
+        cd ../tensorflow-$TENSORFLOW_VERSION
         ;;
     *)
         echo "Error: Platform \"$PLATFORM\" is not supported"

--- a/tensorflow/pom.xml
+++ b/tensorflow/pom.xml
@@ -81,30 +81,30 @@
             <includePath>${tensorflow.path}/bazel-tensorflow-${tensorflow.version}/external/protobuf_archive/src/</includePath>
             <includePath>${tensorflow.path}/bazel-tensorflow-${tensorflow.version}/external/eigen_archive/</includePath>
             <includePath>${tensorflow.path}/bazel-tensorflow-${tensorflow.version}/external/eigen_archive/eigen-eigen-d02e6a705c30/</includePath>
-            <includePath>${tensorflow.path}/tensorflow/contrib/cmake/build/</includePath>
-            <includePath>${tensorflow.path}/tensorflow/contrib/cmake/build/zlib/src/zlib/</includePath>
-            <includePath>${tensorflow.path}/tensorflow/contrib/cmake/build/nsync/src/nsync/public/</includePath>
-            <includePath>${tensorflow.path}/tensorflow/contrib/cmake/build/protobuf/src/protobuf/src/</includePath>
-            <includePath>${tensorflow.path}/tensorflow/contrib/cmake/build/eigen/src/eigen/</includePath>
+            <includePath>${tensorflow.path}/../build/</includePath>
+            <includePath>${tensorflow.path}/../build/zlib/src/zlib/</includePath>
+            <includePath>${tensorflow.path}/../build/nsync/src/nsync/public/</includePath>
+            <includePath>${tensorflow.path}/../build/protobuf/src/protobuf/src/</includePath>
+            <includePath>${tensorflow.path}/../build/eigen/src/eigen/</includePath>
             <includePath>${basedir}/target/classes/org/bytedeco/javacpp/include/</includePath>
           </includePaths>
           <linkPaths>
              <linkPath>${tensorflow.path}/bazel-bin/tensorflow/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/zlib/src/zlib/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/grpc/src/grpc/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/farmhash/src/farmhash/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/fft2d/src/fft2d/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/lmdb/src/lmdb-build/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/gif/src/gif-build/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/jpeg/src/jpeg-build/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/png/src/png-build/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/nsync/src/nsync/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/protobuf/src/protobuf/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/re2/src/re2/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/snappy/src/snappy/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/sqlite/src/sqlite-build/Release/</linkPath>
-             <linkPath>${tensorflow.path}/tensorflow/contrib/cmake/build/tf_cc_op_gen_main.dir/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/zlib/src/zlib/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/grpc/src/grpc/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/farmhash/src/farmhash/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/fft2d/src/fft2d/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/lmdb/src/lmdb-build/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/gif/src/gif-build/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/jpeg/src/jpeg-build/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/png/src/png-build/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/nsync/src/nsync/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/protobuf/src/protobuf/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/re2/src/re2/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/snappy/src/snappy/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/sqlite/src/sqlite-build/Release/</linkPath>
+             <linkPath>${tensorflow.path}/../build/tf_cc_op_gen_main.dir/Release/</linkPath>
           </linkPaths>
           <targetDirectory>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/java/</targetDirectory>
         </configuration>

--- a/tensorflow/src/main/java/org/bytedeco/javacpp/presets/tensorflow.java
+++ b/tensorflow/src/main/java/org/bytedeco/javacpp/presets/tensorflow.java
@@ -195,12 +195,28 @@ import java.lang.annotation.Target;
                 preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x86/Microsoft.VC140.CRT/",
                                "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86/"}),
         @Platform(
-                value = "windows-x86_64",
-                preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT/",
-                               "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"}),
-        @Platform(
-                value = {"linux-x86_64", "macosx-x86_64", "windows-x86_64"},
+                value = "windows-x86_64",							   		
+                preloadpath = {	"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT/",
+								"C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"}),
+
+		@Platform(
+                value = {"windows-x86_64"},
+                extension = "-gpu",
+				link = {"Advapi32#", "zlibstatic", "gpr", "grpc_unsecure", "grpc++_unsecure", "farmhash", "fft2d",
+                        "lmdb", "giflib", "libjpeg", "libpng12_static", "nsync", "libprotobuf", "re2", "snappy", "sqlite", 
+						
+						"cuda@.9.2", "cudnn@.7", "cublas@.9.2", "cublas_device@.9.2", "cufft@.9.2", "cufftw@.9.2",  
+						"curand@.9.2", "cusolver@.9.2", "cusparse@.9.2", "cudart@.9.2", "cudart_static@.9.2", "cupti@.9.2", 
+																			
+						"tensorflow_static", "tf_core_gpu_kernels", "tf_protos_cc", "tf_cc_op_gen_main"},
+				includepath = { "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/include/"}, 
+				linkpath = {	"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/lib/x64/",  
+								"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/extras/CUPTI/libx64/"}), 	
+								
+		@Platform(
+                value = {"linux-x86_64", "macosx-x86_64"},
                 extension = "-gpu"),
+				
         @Platform(
                 value = {"android"},
                 compiler = {"cpp11"},

--- a/tensorflow/src/main/java/org/bytedeco/javacpp/presets/tensorflow.java
+++ b/tensorflow/src/main/java/org/bytedeco/javacpp/presets/tensorflow.java
@@ -182,10 +182,13 @@ import java.lang.annotation.Target;
                         "tensorflow/cc/ops/user_ops.h"},
                 link = "tensorflow_cc", preload = "tensorflow_framework"),
         @Platform(
+                value = {"linux-x86_64", "macosx-x86_64"},
+                extension = "-gpu"),
+        @Platform(
                 value = "windows",
                 link = {"Advapi32#", "zlibstatic", "gpr", "grpc_unsecure", "grpc++_unsecure", "farmhash", "fft2d",
-                        "lmdb", "giflib", "libjpeg", "libpng12_static", "nsync", "libprotobuf", "re2", "snappy",
-                        "sqlite", "tensorflow_static", "tf_protos_cc", "tf_cc_op_gen_main"},
+                        "lmdb", "giflib", "libjpeg", "libpng12_static", "nsync", "libprotobuf", "re2", "snappy", "sqlite",
+                        "tensorflow_static", "tf_protos_cc", "tf_cc_op_gen_main"},
                 preload = {"concrt140", "msvcp140", "vcruntime140",
                            "api-ms-win-crt-locale-l1-1-0", "api-ms-win-crt-string-l1-1-0", "api-ms-win-crt-stdio-l1-1-0", "api-ms-win-crt-math-l1-1-0",
                            "api-ms-win-crt-heap-l1-1-0", "api-ms-win-crt-runtime-l1-1-0", "api-ms-win-crt-convert-l1-1-0", "api-ms-win-crt-environment-l1-1-0",
@@ -195,28 +198,20 @@ import java.lang.annotation.Target;
                 preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x86/Microsoft.VC140.CRT/",
                                "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x86/"}),
         @Platform(
-                value = "windows-x86_64",							   		
-                preloadpath = {	"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT/",
-								"C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"}),
-
-		@Platform(
-                value = {"windows-x86_64"},
+                value = "windows-x86_64",
+                preloadpath = {"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT/",
+                               "C:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64/"}),
+        @Platform(
+                value = "windows-x86_64",
                 extension = "-gpu",
-				link = {"Advapi32#", "zlibstatic", "gpr", "grpc_unsecure", "grpc++_unsecure", "farmhash", "fft2d",
-                        "lmdb", "giflib", "libjpeg", "libpng12_static", "nsync", "libprotobuf", "re2", "snappy", "sqlite", 
-						
-						"cuda@.9.2", "cudnn@.7", "cublas@.9.2", "cublas_device@.9.2", "cufft@.9.2", "cufftw@.9.2",  
-						"curand@.9.2", "cusolver@.9.2", "cusparse@.9.2", "cudart@.9.2", "cudart_static@.9.2", "cupti@.9.2", 
-																			
-						"tensorflow_static", "tf_core_gpu_kernels", "tf_protos_cc", "tf_cc_op_gen_main"},
-				includepath = { "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/include/"}, 
-				linkpath = {	"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/lib/x64/",  
-								"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/extras/CUPTI/libx64/"}), 	
-								
-		@Platform(
-                value = {"linux-x86_64", "macosx-x86_64"},
-                extension = "-gpu"),
-				
+                link = {"Advapi32#", "zlibstatic", "gpr", "grpc_unsecure", "grpc++_unsecure", "farmhash", "fft2d",
+                        "lmdb", "giflib", "libjpeg", "libpng12_static", "nsync", "libprotobuf", "re2", "snappy", "sqlite",
+                        "cudart", "cudart_static", "cuda", "cublas", "cublas_device", "cudnn",
+                        "cufft", "cufftw", "curand", "cusolver", "cusparse", "cupti",
+                        "tf_core_gpu_kernels", "tensorflow_static", "tf_protos_cc", "tf_cc_op_gen_main"},
+                includepath = {"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/include/"},
+                linkpath    = {"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/lib/x64/",
+                               "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.2/extras/CUPTI/libx64/"}),
         @Platform(
                 value = {"android"},
                 compiler = {"cpp11"},


### PR DESCRIPTION
Tested with cuda 9.0 + cudnn 7.0 and cuda 9.2 + cudnn 7.1

Is it possible to merge attributes from other platform annotation? Right now I had to copy the "link" attributes from the "windows" platform to the "windows-x86_64" with "-gpu" extension.

Furthermore it might be better to exchange the "-gpu" extension with "-cuda90" or "-cuda92". On the other hand all the different configurations are horrible (e.g. cuda version, cudnn version, cpu instruction set) to maintain.