### PR TITLE
Multi processor compilation for windows builds

### DIFF
--- a/hdf5/cppbuild.sh
+++ b/hdf5/cppbuild.sh
@@ -79,7 +79,7 @@ case $PLATFORM in
 	cd build
         "$CMAKE" -G "Visual Studio 14 2015" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DBUILD_TESTING=false -DHDF5_BUILD_EXAMPLES=false -DHDF5_BUILD_TOOLS=false -DHDF5_ALLOW_EXTERNAL_SUPPORT:STRING="TGZ" -DZLIB_TGZ_NAME:STRING="$ZLIB.tar.gz" -DTGZPATH:STRING="$INSTALL_PATH/.." -DHDF5_ENABLE_Z_LIB_SUPPORT=ON ..
 	sedinplace 's/libzlib.lib/zlibstatic.lib/g' src/hdf5-shared.vcxproj
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
 	cp bin/Release/zlib* ../../lib/
 	cd ..
         ;;
@@ -88,7 +88,7 @@ case $PLATFORM in
 	cd build
         "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DBUILD_TESTING=false -DHDF5_BUILD_EXAMPLES=false -DHDF5_BUILD_TOOLS=false -DHDF5_ALLOW_EXTERNAL_SUPPORT:STRING="TGZ" -DZLIB_TGZ_NAME:STRING="$ZLIB.tar.gz" -DTGZPATH:STRING="$INSTALL_PATH/.." -DHDF5_ENABLE_Z_LIB_SUPPORT=ON ..
 	sedinplace 's/libzlib.lib/zlibstatic.lib/g' src/hdf5-shared.vcxproj
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
 	cp bin/Release/zlib* ../../lib/
 	cd ..
         ;;

--- a/llvm/cppbuild.sh
+++ b/llvm/cppbuild.sh
@@ -53,13 +53,13 @@ case $PLATFORM in
         ;;
     windows-x86)
         $CMAKE -G "Visual Studio 14 2015" -DLLVM_USE_CRT_RELEASE=MD -DCMAKE_INSTALL_PREFIX=../.. -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host -DLLVM_ENABLE_DIA_SDK=OFF -DLIBXML2_LIBRARIES= -DPYTHON_EXECUTABLE="C:/Python27/python.exe" ..
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
         cd Release/lib/
         [ -f LLVM.lib ] || lib.exe /OUT:LLVM.lib LLVM*.lib
         [ -f clang.lib ] || lib.exe /OUT:clang.lib clang*.lib
         cd ../..
         $CMAKE -G "Visual Studio 14 2015" -DLLVM_USE_CRT_RELEASE=MD -DCMAKE_INSTALL_PREFIX=../.. -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host -DLLVM_ENABLE_DIA_SDK=OFF -DLIBXML2_LIBRARIES= -DPYTHON_EXECUTABLE="C:/Python27/python.exe" ..
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
         cd ../../lib
         [ -f LLVM.lib ] || lib.exe /OUT:LLVM.lib LLVM*.lib
         [ -f clang.lib ] || lib.exe /OUT:clang.lib clang*.lib
@@ -68,13 +68,13 @@ case $PLATFORM in
         ;;
     windows-x86_64)
         $CMAKE -G "Visual Studio 14 2015 Win64" -Thost=x64 -DLLVM_USE_CRT_RELEASE=MD -DCMAKE_INSTALL_PREFIX=../.. -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host -DLLVM_ENABLE_DIA_SDK=OFF -DLIBXML2_LIBRARIES= -DPYTHON_EXECUTABLE="C:/Python27/python.exe" ..
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
         cd Release/lib/
         [ -f LLVM.lib ] || lib.exe /OUT:LLVM.lib LLVM*.lib
         [ -f clang.lib ] || lib.exe /OUT:clang.lib clang*.lib
         cd ../..
         $CMAKE -G "Visual Studio 14 2015 Win64" -Thost=x64 -DLLVM_USE_CRT_RELEASE=MD -DCMAKE_INSTALL_PREFIX=../.. -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host -DLLVM_ENABLE_DIA_SDK=OFF -DLIBXML2_LIBRARIES= -DPYTHON_EXECUTABLE="C:/Python27/python.exe" ..
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
         cd ../../lib
         [ -f LLVM.lib ] || lib.exe /OUT:LLVM.lib LLVM*.lib
         [ -f clang.lib ] || lib.exe /OUT:clang.lib clang*.lib

--- a/mkl-dnn/cppbuild.sh
+++ b/mkl-dnn/cppbuild.sh
@@ -45,7 +45,7 @@ case $PLATFORM in
         mkdir -p external
         unzip -o mklml_win_$MKLML_VERSION.zip -d external
         "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
         cp external/mklml_win_$MKLML_VERSION/include/* ../include/
         cp external/mklml_win_$MKLML_VERSION/lib/*.lib ../lib/
         ;;

--- a/opencv/cppbuild.sh
+++ b/opencv/cppbuild.sh
@@ -166,7 +166,7 @@ case $PLATFORM in
         ;;
     windows-x86)
         "$CMAKE" -G "Visual Studio 14 2015" -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH" -DCMAKE_INSTALL_LIBDIR="lib" $BUILD_X -DENABLE_PRECOMPILED_HEADERS=ON $WITH_X -DWITH_OPENMP=OFF $GPU_FLAGS -DWITH_IPP=OFF $BUILD_CONTRIB_X
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
         cp -r ../x86/vc14/lib ..
         cp -r ../x86/vc14/bin ..
         cp lib/Release/opencv_java.lib ../lib
@@ -176,7 +176,7 @@ case $PLATFORM in
         ;;
     windows-x86_64)
         "$CMAKE" -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH" -DCMAKE_INSTALL_LIBDIR="lib" $BUILD_X -DENABLE_PRECOMPILED_HEADERS=ON $WITH_X -DWITH_OPENMP=OFF $GPU_FLAGS -DWITH_IPP=OFF $BUILD_CONTRIB_X
-        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //maxcpucount:$MAKEJ
+        MSBuild.exe INSTALL.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ
         cp -r ../x64/vc14/lib ..
         cp -r ../x64/vc14/bin ..
         cp lib/Release/opencv_java.lib ../lib

--- a/tensorflow/cppbuild.sh
+++ b/tensorflow/cppbuild.sh
@@ -153,13 +153,13 @@ case $PLATFORM in
         cd ../build
         "$CMAKE" -A x64 -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE="C:/Python27/python.exe" -DSWIG_EXECUTABLE="C:/swigwin-3.0.12/swig.exe" -Dtensorflow_BUILD_PYTHON_BINDINGS=ON -Dtensorflow_BUILD_SHARED_LIB=ON -Dtensorflow_WIN_CPU_SIMD_OPTIONS=/arch:AVX -G"Visual Studio 14" -Dtensorflow_ENABLE_MKLDNN_SUPPORT=ON $CMAKE_GPU_FLAGS -DCUDNN_HOME="$CUDA_PATH" ../tensorflow-$TENSORFLOW_VERSION/tensorflow/contrib/cmake
         if [[ ! -f ../build/Release/tensorflow_static.lib ]]; then
-            MSBuild.exe //p:Configuration=Release //maxcpucount:$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tensorflow_static.vcxproj
+            MSBuild.exe //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tensorflow_static.vcxproj
         fi
         if [[ ! -f ../build/tf_c_python_api.dir/Release/tf_c_python_api.lib ]]; then
-            MSBuild.exe //p:Configuration=Release //maxcpucount:$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tf_c_python_api.vcxproj
+            MSBuild.exe //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tf_c_python_api.vcxproj
         fi
         if [[ "$EXTENSION" == *gpu ]] && [[ "${PARTIAL_CPPBUILD:-}" != "1" ]]; then
-            MSBuild.exe //p:Configuration=Release //maxcpucount:$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tf_core_gpu_kernels.vcxproj
+            MSBuild.exe //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tf_core_gpu_kernels.vcxproj
         fi
         cd ../tensorflow-$TENSORFLOW_VERSION
         ;;


### PR DESCRIPTION
Like I mentioned in #568 compilation using multiple cores does not work correctly right now. We are using `/maxcpucount` which builds multiple projects at ones. To compile in parallel we need to tell the compiler (cl.exe) to use multiple cores.

Reference
https://msdn.microsoft.com/en-us/library/bb385193.aspx?f=255&MSPPError=-2147217396
> /maxcpucount: the MSBuild.exe tool can build multiple projects at the same time
> /MP: compiler (cl.exe) option can build multiple compilation units at the same time