### PR TITLE
Tensorflow partial builds for windows

### DIFF
--- a/tensorflow/cppbuild.sh
+++ b/tensorflow/cppbuild.sh
@@ -151,16 +151,45 @@ case $PLATFORM in
         patch -Np1 < ../../../tensorflow-windows.patch
         mkdir -p ../build
         cd ../build
+		
         "$CMAKE" -A x64 -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE="C:/Python27/python.exe" -DSWIG_EXECUTABLE="C:/swigwin-3.0.12/swig.exe" -Dtensorflow_BUILD_PYTHON_BINDINGS=ON -Dtensorflow_BUILD_SHARED_LIB=ON -Dtensorflow_WIN_CPU_SIMD_OPTIONS=/arch:AVX -G"Visual Studio 14" -Dtensorflow_ENABLE_MKLDNN_SUPPORT=ON $CMAKE_GPU_FLAGS -DCUDNN_HOME="$CUDA_PATH" ../tensorflow-$TENSORFLOW_VERSION/tensorflow/contrib/cmake
-        if [[ ! -f ../build/Release/tensorflow_static.lib ]]; then
-            MSBuild.exe //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tensorflow_static.vcxproj
-        fi
-        if [[ ! -f ../build/tf_c_python_api.dir/Release/tf_c_python_api.lib ]]; then
-            MSBuild.exe //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tf_c_python_api.vcxproj
-        fi
-        if [[ "$EXTENSION" == *gpu ]] && [[ "${PARTIAL_CPPBUILD:-}" != "1" ]]; then
-            MSBuild.exe //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger tf_core_gpu_kernels.vcxproj
-        fi
+        
+		# partial build if the variable is not set or set to 1
+		if [[ "${PARTIAL_CPPBUILD:-1}" == "1" ]]; then
+		
+			# two xeon core need around 30min
+			MSBuild.exe tf_c.vcxproj //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger
+			MSBuild.exe tf_core_cpu.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger
+			MSBuild.exe tf_cc.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger	
+			MSBuild.exe tf_core_ops.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger		
+			MSBuild.exe tf_core_kernels_cpu_only.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger 		
+			MSBuild.exe tf_stream_executor.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger
+			MSBuild.exe tf_core_distributed_runtime.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger
+			MSBuild.exe tf_core_direct_session.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger
+			
+			# two xeon core need around 1h 40min
+			if [[ "$EXTENSION" == *gpu ]]; then
+				MSBuild.exe tf_core_gpu_kernels.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger 
+			fi
+			
+			# two xeon core need around 2min
+			if [[ ! -f ../build/tf_c_python_api.dir/Release/tf_c_python_api.lib ]]; then
+				MSBuild.exe tf_python_protos_cc.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger 
+				MSBuild.exe tf_c_python_api.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger 
+			fi
+		fi
+			
+		# the remaining parts, if the variable is not set or set to 0
+		if [[ "${PARTIAL_CPPBUILD:-0}" == "0" ]]; then
+	
+			# two xeon core need around 3h 15min
+			if [[ ! -f ../build/Release/tensorflow_static.lib ]] && [[ "${PARTIAL_CPPBUILD:-}" != "1" ]]; then
+				MSBuild.exe tf_core_kernels.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger 
+				MSBuild.exe tf_tools_transform_graph_lib.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger 
+				MSBuild.exe tensorflow_static.vcxproj //p:BuildProjectReferences=false //p:Configuration=Release //p:CL_MPCount=$MAKEJ //p:Platform=x64 //p:PreferredToolArchitecture=x64 //filelogger
+			fi
+		fi
+		
         cd ../tensorflow-$TENSORFLOW_VERSION
         ;;
     *)


### PR DESCRIPTION
The build is separated in two phases the first one is marked blue in the figure below and the second is green. The run-time for a 2 core xeon is about 2h 30min for the first part and 3h 20min for the second.

![Build time of different Tensorflow modules](https://visual-computing.com/resources/javacpp/build_times_tensorflow_2cores.svg "Build time of different Tensorflow modules")