### PR TITLE
Build with Traditional ML support (ONNX-ML)

### DIFF
--- a/onnx/README.md
+++ b/onnx/README.md
@@ -57,7 +57,9 @@ import static org.bytedeco.javacpp.onnx.*;
 
 public class LoadModel {
     public static void main(String[] args) throws Exception {
-        OpSchemaRegistry.get_all_schemas();
+        RegisterOnnxMLOperatorSetSchema();
+        OpSchemaVector allSchemas = OpSchemaRegistry.get_all_schemas();
+        System.out.println(allSchemas.size());
 
         byte[] bytes = Files.readAllBytes(Paths.get("examples/resources/single_relu.onnx"));
 

--- a/onnx/README.md
+++ b/onnx/README.md
@@ -57,7 +57,6 @@ import static org.bytedeco.javacpp.onnx.*;
 
 public class LoadModel {
     public static void main(String[] args) throws Exception {
-        RegisterOnnxMLOperatorSetSchema();
         OpSchemaVector allSchemas = OpSchemaRegistry.get_all_schemas();
         System.out.println(allSchemas.size());
 

--- a/onnx/cppbuild.sh
+++ b/onnx/cppbuild.sh
@@ -45,7 +45,7 @@ rm -df third_party/pybind11
 ln -sf $INSTALL_PATH/pybind11-$PYBIND third_party/pybind11
 
 #to build with "Traditional ML" support. Untested.
-#export ONNX_ML=1
+export ONNX_ML=1
 export CMAKE_BUILD_DIR=.setuptools-cmake-build/
 export CMAKE_ARGS=-DBUILD_SHARED_LIBS=ON
 python3 setup.py build

--- a/onnx/src/main/java/org/bytedeco/javacpp/onnx.java
+++ b/onnx/src/main/java/org/bytedeco/javacpp/onnx.java
@@ -1453,6 +1453,1191 @@ public class onnx extends org.bytedeco.javacpp.presets.onnx {
  // namespace ONNX_NAMESPACE
 
 
+// Parsed from onnx/defs/operator_sets.h
+
+// Copyright (c) Facebook Inc. and Microsoft Corporation.
+// Licensed under the MIT license.
+
+// #pragma once
+
+// #include "onnx/defs/schema.h"
+
+// Forward declarations for ai.onnx version 1
+@Namespace("onnx") @Opaque public static class ATen_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ATen_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ATen_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Abs_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Abs_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Abs_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Add_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Add_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Add_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Affine_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Affine_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Affine_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class And_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public And_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public And_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ArgMax_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ArgMax_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ArgMax_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ArgMin_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ArgMin_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ArgMin_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class AveragePool_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public AveragePool_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public AveragePool_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class BatchNormalization_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public BatchNormalization_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public BatchNormalization_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Cast_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Cast_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Cast_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Ceil_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Ceil_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Ceil_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Clip_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Clip_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Clip_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Concat_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Concat_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Concat_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Constant_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Constant_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Constant_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ConstantFill_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ConstantFill_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ConstantFill_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Conv_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Conv_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Conv_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ConvTranspose_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ConvTranspose_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ConvTranspose_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Crop_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Crop_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Crop_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class DepthToSpace_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public DepthToSpace_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public DepthToSpace_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Div_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Div_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Div_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Dropout_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Dropout_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Dropout_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Elu_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Elu_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Elu_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Equal_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Equal_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Equal_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Exp_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Exp_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Exp_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Flatten_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Flatten_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Flatten_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Floor_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Floor_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Floor_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class GRU_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GRU_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GRU_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class GRUUnit_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GRUUnit_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GRUUnit_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Gather_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Gather_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Gather_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Gemm_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Gemm_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Gemm_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class GivenTensorFill_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GivenTensorFill_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GivenTensorFill_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class GlobalAveragePool_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GlobalAveragePool_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GlobalAveragePool_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class GlobalLpPool_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GlobalLpPool_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GlobalLpPool_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class GlobalMaxPool_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GlobalMaxPool_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GlobalMaxPool_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Greater_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Greater_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Greater_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class HardSigmoid_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public HardSigmoid_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public HardSigmoid_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Hardmax_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Hardmax_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Hardmax_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Identity_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Identity_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Identity_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class If_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public If_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public If_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ImageScaler_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ImageScaler_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ImageScaler_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class InstanceNormalization_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public InstanceNormalization_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public InstanceNormalization_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LRN_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LRN_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LRN_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LSTM_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LSTM_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LSTM_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LeakyRelu_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LeakyRelu_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LeakyRelu_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Less_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Less_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Less_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Log_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Log_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Log_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LogSoftmax_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LogSoftmax_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LogSoftmax_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Loop_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Loop_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Loop_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LoopIndexTensor_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LoopIndexTensor_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LoopIndexTensor_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LpNormalization_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LpNormalization_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LpNormalization_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LpPool_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LpPool_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LpPool_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class MatMul_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public MatMul_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public MatMul_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Max_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Max_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Max_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class MaxPool_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public MaxPool_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public MaxPool_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class MaxRoiPool_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public MaxRoiPool_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public MaxRoiPool_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Mean_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Mean_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Mean_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class MeanVarianceNormalization_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public MeanVarianceNormalization_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public MeanVarianceNormalization_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Min_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Min_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Min_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Mul_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Mul_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Mul_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Neg_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Neg_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Neg_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Not_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Not_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Not_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Or_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Or_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Or_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class PRelu_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public PRelu_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public PRelu_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Pad_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Pad_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Pad_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ParametricSoftplus_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ParametricSoftplus_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ParametricSoftplus_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Pow_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Pow_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Pow_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class RNN_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public RNN_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public RNN_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class RandomNormal_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public RandomNormal_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public RandomNormal_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class RandomNormalLike_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public RandomNormalLike_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public RandomNormalLike_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class RandomUniform_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public RandomUniform_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public RandomUniform_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class RandomUniformLike_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public RandomUniformLike_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public RandomUniformLike_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Reciprocal_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Reciprocal_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Reciprocal_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceL1_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceL1_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceL1_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceL2_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceL2_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceL2_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceLogSum_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceLogSum_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceLogSum_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceLogSumExp_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceLogSumExp_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceLogSumExp_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceMax_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceMax_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceMax_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceMean_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceMean_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceMean_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceMin_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceMin_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceMin_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceProd_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceProd_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceProd_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceSum_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceSum_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceSum_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ReduceSumSquare_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ReduceSumSquare_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ReduceSumSquare_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Relu_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Relu_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Relu_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Reshape_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Reshape_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Reshape_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Scale_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Scale_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Scale_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ScaledTanh_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ScaledTanh_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ScaledTanh_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Selu_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Selu_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Selu_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Shape_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Shape_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Shape_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sigmoid_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sigmoid_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sigmoid_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Size_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Size_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Size_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Slice_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Slice_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Slice_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Softmax_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Softmax_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Softmax_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Softplus_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Softplus_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Softplus_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Softsign_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Softsign_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Softsign_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class SpaceToDepth_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public SpaceToDepth_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public SpaceToDepth_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Split_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Split_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Split_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sqrt_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sqrt_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sqrt_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Squeeze_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Squeeze_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Squeeze_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sub_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sub_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sub_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sum_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sum_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sum_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Tanh_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Tanh_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Tanh_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ThresholdedRelu_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ThresholdedRelu_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ThresholdedRelu_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Tile_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Tile_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Tile_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class TopK_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public TopK_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public TopK_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Transpose_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Transpose_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Transpose_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Unsqueeze_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Unsqueeze_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Unsqueeze_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Upsample_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Upsample_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Upsample_Onnx_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Xor_Onnx_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Xor_Onnx_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Xor_Onnx_ver1(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx version 1
+@Namespace("onnx") public static class OpSet_Onnx_ver1 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_Onnx_ver1() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_Onnx_ver1(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_Onnx_ver1(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_Onnx_ver1 position(long position) {
+        return (OpSet_Onnx_ver1)super.position(position);
+    }
+
+}
+
+// Forward declarations for ai.onnx version 2
+@Namespace("onnx") @Opaque public static class GlobalLpPool_Onnx_ver2 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GlobalLpPool_Onnx_ver2() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GlobalLpPool_Onnx_ver2(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LpPool_Onnx_ver2 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LpPool_Onnx_ver2() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LpPool_Onnx_ver2(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Pad_Onnx_ver2 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Pad_Onnx_ver2() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Pad_Onnx_ver2(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Split_Onnx_ver2 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Split_Onnx_ver2() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Split_Onnx_ver2(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx version 2
+@Namespace("onnx") public static class OpSet_Onnx_ver2 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_Onnx_ver2() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_Onnx_ver2(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_Onnx_ver2(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_Onnx_ver2 position(long position) {
+        return (OpSet_Onnx_ver2)super.position(position);
+    }
+
+}
+
+// Forward declarations for ai.onnx version 3
+@Namespace("onnx") @Opaque public static class GRU_Onnx_ver3 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GRU_Onnx_ver3() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GRU_Onnx_ver3(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx version 3
+@Namespace("onnx") public static class OpSet_Onnx_ver3 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_Onnx_ver3() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_Onnx_ver3(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_Onnx_ver3(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_Onnx_ver3 position(long position) {
+        return (OpSet_Onnx_ver3)super.position(position);
+    }
+
+}
+
+// Forward declarations for ai.onnx version 4
+@Namespace("onnx") @Opaque public static class Concat_Onnx_ver4 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Concat_Onnx_ver4() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Concat_Onnx_ver4(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx version 4
+@Namespace("onnx") public static class OpSet_Onnx_ver4 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_Onnx_ver4() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_Onnx_ver4(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_Onnx_ver4(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_Onnx_ver4 position(long position) {
+        return (OpSet_Onnx_ver4)super.position(position);
+    }
+
+}
+
+// Forward declarations for ai.onnx version 5
+@Namespace("onnx") @Opaque public static class Reshape_Onnx_ver5 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Reshape_Onnx_ver5() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Reshape_Onnx_ver5(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx version 5
+@Namespace("onnx") public static class OpSet_Onnx_ver5 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_Onnx_ver5() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_Onnx_ver5(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_Onnx_ver5(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_Onnx_ver5 position(long position) {
+        return (OpSet_Onnx_ver5)super.position(position);
+    }
+
+}
+
+// Forward declarations for ai.onnx version 6
+@Namespace("onnx") @Opaque public static class Abs_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Abs_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Abs_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Add_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Add_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Add_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class BatchNormalization_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public BatchNormalization_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public BatchNormalization_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Cast_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Cast_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Cast_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Ceil_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Ceil_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Ceil_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Clip_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Clip_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Clip_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Div_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Div_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Div_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Dropout_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Dropout_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Dropout_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Elu_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Elu_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Elu_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Exp_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Exp_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Exp_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Floor_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Floor_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Floor_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Gemm_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Gemm_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Gemm_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class HardSigmoid_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public HardSigmoid_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public HardSigmoid_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class InstanceNormalization_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public InstanceNormalization_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public InstanceNormalization_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LeakyRelu_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LeakyRelu_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LeakyRelu_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Log_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Log_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Log_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Max_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Max_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Max_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Mean_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Mean_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Mean_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Min_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Min_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Min_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Mul_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Mul_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Mul_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Neg_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Neg_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Neg_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class PRelu_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public PRelu_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public PRelu_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Reciprocal_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Reciprocal_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Reciprocal_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Relu_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Relu_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Relu_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Selu_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Selu_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Selu_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sigmoid_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sigmoid_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sigmoid_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sqrt_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sqrt_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sqrt_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sub_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sub_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sub_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sum_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sum_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sum_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Tanh_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Tanh_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Tanh_Onnx_ver6(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Tile_Onnx_ver6 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Tile_Onnx_ver6() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Tile_Onnx_ver6(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx version 6
+@Namespace("onnx") public static class OpSet_Onnx_ver6 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_Onnx_ver6() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_Onnx_ver6(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_Onnx_ver6(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_Onnx_ver6 position(long position) {
+        return (OpSet_Onnx_ver6)super.position(position);
+    }
+
+}
+
+// Forward declarations for ai.onnx version 7
+@Namespace("onnx") @Opaque public static class Acos_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Acos_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Acos_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Add_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Add_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Add_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class And_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public And_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public And_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Asin_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Asin_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Asin_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Atan_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Atan_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Atan_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class AveragePool_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public AveragePool_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public AveragePool_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class BatchNormalization_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public BatchNormalization_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public BatchNormalization_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Cos_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Cos_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Cos_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Div_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Div_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Div_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Dropout_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Dropout_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Dropout_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Equal_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Equal_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Equal_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Gemm_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Gemm_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Gemm_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Greater_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Greater_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Greater_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class GRU_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public GRU_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public GRU_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Less_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Less_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Less_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LSTM_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LSTM_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LSTM_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Mul_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Mul_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Mul_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Or_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Or_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Or_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Pow_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Pow_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Pow_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class RNN_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public RNN_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public RNN_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sin_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sin_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sin_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Sub_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Sub_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Sub_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Tan_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Tan_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Tan_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Upsample_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Upsample_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Upsample_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Multinomial_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Multinomial_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Multinomial_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Xor_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Xor_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Xor_Onnx_ver7(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class PRelu_Onnx_ver7 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public PRelu_Onnx_ver7() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public PRelu_Onnx_ver7(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx version 7
+@Namespace("onnx") public static class OpSet_Onnx_ver7 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_Onnx_ver7() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_Onnx_ver7(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_Onnx_ver7(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_Onnx_ver7 position(long position) {
+        return (OpSet_Onnx_ver7)super.position(position);
+    }
+
+}
+
+@Namespace("onnx") public static native void RegisterOnnxOperatorSetSchema();
+
+ // namespace ONNX_NAMESPACE
+
+
 // Parsed from onnx/defs/operator_sets-ml.h
 
 // Copyright (c) Facebook Inc. and Microsoft Corporation.

--- a/onnx/src/main/java/org/bytedeco/javacpp/onnx.java
+++ b/onnx/src/main/java/org/bytedeco/javacpp/onnx.java
@@ -1453,6 +1453,150 @@ public class onnx extends org.bytedeco.javacpp.presets.onnx {
  // namespace ONNX_NAMESPACE
 
 
+// Parsed from onnx/defs/operator_sets-ml.h
+
+// Copyright (c) Facebook Inc. and Microsoft Corporation.
+// Licensed under the MIT license.
+
+// #pragma once
+
+// #ifdef ONNX_ML
+
+// #include "onnx/defs/schema.h"
+
+// Forward declarations for ai.onnx.ml version 1
+@Namespace("onnx") @Opaque public static class ArrayFeatureExtractor_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ArrayFeatureExtractor_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ArrayFeatureExtractor_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Binarizer_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Binarizer_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Binarizer_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class CastMap_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public CastMap_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public CastMap_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class CategoryMapper_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public CategoryMapper_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public CategoryMapper_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class DictVectorizer_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public DictVectorizer_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public DictVectorizer_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class FeatureVectorizer_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public FeatureVectorizer_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public FeatureVectorizer_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Imputer_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Imputer_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Imputer_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LabelEncoder_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LabelEncoder_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LabelEncoder_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LinearClassifier_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LinearClassifier_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LinearClassifier_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class LinearRegressor_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public LinearRegressor_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public LinearRegressor_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Normalizer_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Normalizer_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Normalizer_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class OneHotEncoder_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public OneHotEncoder_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OneHotEncoder_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class SVMClassifier_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public SVMClassifier_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public SVMClassifier_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class SVMRegressor_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public SVMRegressor_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public SVMRegressor_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class Scaler_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public Scaler_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public Scaler_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class TreeEnsembleClassifier_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public TreeEnsembleClassifier_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public TreeEnsembleClassifier_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class TreeEnsembleRegressor_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public TreeEnsembleRegressor_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public TreeEnsembleRegressor_OnnxML_ver1(Pointer p) { super(p); }
+}
+@Namespace("onnx") @Opaque public static class ZipMap_OnnxML_ver1 extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public ZipMap_OnnxML_ver1() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public ZipMap_OnnxML_ver1(Pointer p) { super(p); }
+}
+
+// Iterate over schema from ai.onnx.ml version 1
+@Namespace("onnx") public static class OpSet_OnnxML_ver1 extends Pointer {
+    static { Loader.load(); }
+    /** Default native constructor. */
+    public OpSet_OnnxML_ver1() { super((Pointer)null); allocate(); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public OpSet_OnnxML_ver1(long size) { super((Pointer)null); allocateArray(size); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public OpSet_OnnxML_ver1(Pointer p) { super(p); }
+    private native void allocate();
+    private native void allocateArray(long size);
+    @Override public OpSet_OnnxML_ver1 position(long position) {
+        return (OpSet_OnnxML_ver1)super.position(position);
+    }
+
+}
+
+@Namespace("onnx") public static native void RegisterOnnxMLOperatorSetSchema();
+ // namespace ONNX_NAMESPACE
+
+// #endif
+
+
 // Parsed from onnx/defs/data_type_utils.h
 
 // Copyright (c) Facebook Inc. and Microsoft Corporation.
@@ -1666,13 +1810,13 @@ public class onnx extends org.bytedeco.javacpp.presets.onnx {
  // namespace ONNX_NAMESPACE
 
 
-// Parsed from onnx/onnx-operators.pb.h
+// Parsed from onnx/onnx-operators-ml.pb.h
 
 // Generated by the protocol buffer compiler.  DO NOT EDIT!
-// source: onnx-operators.proto
+// source: onnx-operators-ml.proto
 
-// #ifndef PROTOBUF_onnx_2doperators_2eproto__INCLUDED
-// #define PROTOBUF_onnx_2doperators_2eproto__INCLUDED
+// #ifndef PROTOBUF_onnx_2doperators_2dml_2eproto__INCLUDED
+// #define PROTOBUF_onnx_2doperators_2dml_2eproto__INCLUDED
 
 // #include <string>
 
@@ -1700,10 +1844,10 @@ public class onnx extends org.bytedeco.javacpp.presets.onnx {
 // #include <google/protobuf/extension_set.h>  // IWYU pragma: export
 // #include <google/protobuf/generated_enum_reflection.h>
 // #include <google/protobuf/unknown_field_set.h>
-// #include "onnx.pb.h"
+// #include "onnx-ml.pb.h"
 // @@protoc_insertion_point(includes)
 // Internal implementation detail -- do not use these members.
-@Namespace("protobuf_onnx_2doperators_2eproto") public static class TableStruct extends Pointer {
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static class TableStruct extends Pointer {
     static { Loader.load(); }
     /** Default native constructor. */
     public TableStruct() { super((Pointer)null); allocate(); }
@@ -1720,15 +1864,15 @@ public class onnx extends org.bytedeco.javacpp.presets.onnx {
   @MemberGetter public static native @Cast("const google::protobuf::uint32") int offsets(int i);
   @MemberGetter public static native @Cast("const google::protobuf::uint32*") IntPointer offsets();
 }
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void AddDescriptors();
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void InitDefaultsFunctionProtoImpl();
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void InitDefaultsFunctionProto();
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void InitDefaultsOperatorProtoImpl();
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void InitDefaultsOperatorProto();
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void InitDefaultsOperatorSetProtoImpl();
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void InitDefaultsOperatorSetProto();
-@Namespace("protobuf_onnx_2doperators_2eproto") public static native void InitDefaults();
-  // namespace protobuf_onnx_2doperators_2eproto
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void AddDescriptors();
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void InitDefaultsFunctionProtoImpl();
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void InitDefaultsFunctionProto();
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void InitDefaultsOperatorProtoImpl();
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void InitDefaultsOperatorProto();
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void InitDefaultsOperatorSetProtoImpl();
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void InitDefaultsOperatorSetProto();
+@Namespace("protobuf_onnx_2doperators_2dml_2eproto") public static native void InitDefaults();
+  // namespace protobuf_onnx_2doperators_2dml_2eproto
 @Namespace("onnx") @Opaque public static class FunctionProtoDefaultTypeInternal extends Pointer {
     /** Empty constructor. Calls {@code super((Pointer)null)}. */
     public FunctionProtoDefaultTypeInternal() { super((Pointer)null); }
@@ -2576,16 +2720,16 @@ public static final int
 
 // @@protoc_insertion_point(global_scope)
 
-// #endif  // PROTOBUF_onnx_2doperators_2eproto__INCLUDED
+// #endif  // PROTOBUF_onnx_2doperators_2dml_2eproto__INCLUDED
 
 
-// Parsed from onnx/onnx.pb.h
+// Parsed from onnx/onnx-ml.pb.h
 
 // Generated by the protocol buffer compiler.  DO NOT EDIT!
-// source: onnx.proto
+// source: onnx-ml.proto
 
-// #ifndef PROTOBUF_onnx_2eproto__INCLUDED
-// #define PROTOBUF_onnx_2eproto__INCLUDED
+// #ifndef PROTOBUF_onnx_2dml_2eproto__INCLUDED
+// #define PROTOBUF_onnx_2dml_2eproto__INCLUDED
 
 // #include <string>
 
@@ -2615,29 +2759,29 @@ public static final int
 // #include <google/protobuf/unknown_field_set.h>
 // @@protoc_insertion_point(includes)
 // Internal implementation detail -- do not use these members.
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsAttributeProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsAttributeProto();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsValueInfoProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsValueInfoProto();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsModelProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsModelProto();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsStringStringEntryProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsStringStringEntryProto();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorProto_SegmentImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorProto_Segment();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorProto();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorShapeProto_DimensionImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorShapeProto_Dimension();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorShapeProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTensorShapeProto();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTypeProto_TensorImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTypeProto_Tensor();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTypeProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsTypeProto();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsOperatorSetIdProtoImpl();
-@Namespace("protobuf_onnx_2eproto") public static native void InitDefaultsOperatorSetIdProto();
-  // namespace protobuf_onnx_2eproto
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsAttributeProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsAttributeProto();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsValueInfoProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsValueInfoProto();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsModelProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsModelProto();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsStringStringEntryProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsStringStringEntryProto();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorProto_SegmentImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorProto_Segment();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorProto();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorShapeProto_DimensionImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorShapeProto_Dimension();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorShapeProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTensorShapeProto();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTypeProto_TensorImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTypeProto_Tensor();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTypeProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsTypeProto();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsOperatorSetIdProtoImpl();
+@Namespace("protobuf_onnx_2dml_2eproto") public static native void InitDefaultsOperatorSetIdProto();
+  // namespace protobuf_onnx_2dml_2eproto
 @Namespace("onnx") @Opaque public static class AttributeProtoDefaultTypeInternal extends Pointer {
     /** Empty constructor. Calls {@code super((Pointer)null)}. */
     public AttributeProtoDefaultTypeInternal() { super((Pointer)null); }
@@ -2713,6 +2857,20 @@ public static final int
     public TypeProtoDefaultTypeInternal() { super((Pointer)null); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public TypeProtoDefaultTypeInternal(Pointer p) { super(p); }
+}
+
+@Namespace("onnx") @Opaque public static class TypeProto_MapDefaultTypeInternal extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public TypeProto_MapDefaultTypeInternal() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public TypeProto_MapDefaultTypeInternal(Pointer p) { super(p); }
+}
+
+@Namespace("onnx") @Opaque public static class TypeProto_SequenceDefaultTypeInternal extends Pointer {
+    /** Empty constructor. Calls {@code super((Pointer)null)}. */
+    public TypeProto_SequenceDefaultTypeInternal() { super((Pointer)null); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public TypeProto_SequenceDefaultTypeInternal(Pointer p) { super(p); }
 }
 
 @Namespace("onnx") @Opaque public static class TypeProto_TensorDefaultTypeInternal extends Pointer {
@@ -4425,6 +4583,168 @@ public static final int
 }
 // -------------------------------------------------------------------
 
+@Namespace("onnx") @NoOffset public static class TypeProto_Sequence extends MessageLite {
+    static { Loader.load(); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public TypeProto_Sequence(Pointer p) { super(p); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public TypeProto_Sequence(long size) { super((Pointer)null); allocateArray(size); }
+    private native void allocateArray(long size);
+    @Override public TypeProto_Sequence position(long position) {
+        return (TypeProto_Sequence)super.position(position);
+    }
+
+  public TypeProto_Sequence() { super((Pointer)null); allocate(); }
+  private native void allocate();
+
+  public TypeProto_Sequence(@Const @ByRef TypeProto_Sequence from) { super((Pointer)null); allocate(from); }
+  private native void allocate(@Const @ByRef TypeProto_Sequence from);
+
+  public native @ByRef @Name("operator =") TypeProto_Sequence put(@Const @ByRef TypeProto_Sequence from);
+//   #if LANG_CXX11
+//   #endif
+  public native @Const @ByRef UnknownFieldSet unknown_fields();
+  public native UnknownFieldSet mutable_unknown_fields();
+
+  public static native @Cast("const google::protobuf::Descriptor*") Pointer descriptor();
+  public static native @Const @ByRef TypeProto_Sequence default_instance();
+
+  public static native void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  public static native @Const TypeProto_Sequence internal_default_instance();
+  @MemberGetter public static native int kIndexInFileMessages();
+  public static final int kIndexInFileMessages = kIndexInFileMessages();
+
+  public native void Swap(TypeProto_Sequence other);
+  
+
+  // implements Message ----------------------------------------------
+
+  public native TypeProto_Sequence New();
+
+  public native TypeProto_Sequence New(Arena arena);
+  public native void CopyFrom(@Cast("const google::protobuf::Message*") @ByRef MessageLite from);
+  public native void MergeFrom(@Cast("const google::protobuf::Message*") @ByRef MessageLite from);
+  public native void CopyFrom(@Const @ByRef TypeProto_Sequence from);
+  public native void MergeFrom(@Const @ByRef TypeProto_Sequence from);
+  public native void Clear();
+  public native @Cast("bool") boolean IsInitialized();
+
+  public native @Cast("size_t") long ByteSizeLong();
+  public native @Cast("bool") boolean MergePartialFromCodedStream(
+        CodedInputStream input);
+  public native void SerializeWithCachedSizes(
+        CodedOutputStream output);
+  public native @Cast("google::protobuf::uint8*") BytePointer InternalSerializeWithCachedSizesToArray(
+        @Cast("bool") boolean deterministic, @Cast("google::protobuf::uint8*") BytePointer target);
+  public native @Cast("google::protobuf::uint8*") ByteBuffer InternalSerializeWithCachedSizesToArray(
+        @Cast("bool") boolean deterministic, @Cast("google::protobuf::uint8*") ByteBuffer target);
+  public native @Cast("google::protobuf::uint8*") byte[] InternalSerializeWithCachedSizesToArray(
+        @Cast("bool") boolean deterministic, @Cast("google::protobuf::uint8*") byte[] target);
+  public native int GetCachedSize();
+
+  public native @ByVal @Cast("google::protobuf::Metadata*") Pointer GetMetadata();
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .onnx.TypeProto elem_type = 1;
+  public native @Cast("bool") boolean has_elem_type();
+  public native void clear_elem_type();
+  @MemberGetter public static native int kElemTypeFieldNumber();
+  public static final int kElemTypeFieldNumber = kElemTypeFieldNumber();
+  public native @Const @ByRef TypeProto elem_type();
+  public native TypeProto release_elem_type();
+  public native TypeProto mutable_elem_type();
+  public native void set_allocated_elem_type(TypeProto elem_type);
+}
+// -------------------------------------------------------------------
+
+@Namespace("onnx") @NoOffset public static class TypeProto_Map extends MessageLite {
+    static { Loader.load(); }
+    /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
+    public TypeProto_Map(Pointer p) { super(p); }
+    /** Native array allocator. Access with {@link Pointer#position(long)}. */
+    public TypeProto_Map(long size) { super((Pointer)null); allocateArray(size); }
+    private native void allocateArray(long size);
+    @Override public TypeProto_Map position(long position) {
+        return (TypeProto_Map)super.position(position);
+    }
+
+  public TypeProto_Map() { super((Pointer)null); allocate(); }
+  private native void allocate();
+
+  public TypeProto_Map(@Const @ByRef TypeProto_Map from) { super((Pointer)null); allocate(from); }
+  private native void allocate(@Const @ByRef TypeProto_Map from);
+
+  public native @ByRef @Name("operator =") TypeProto_Map put(@Const @ByRef TypeProto_Map from);
+//   #if LANG_CXX11
+//   #endif
+  public native @Const @ByRef UnknownFieldSet unknown_fields();
+  public native UnknownFieldSet mutable_unknown_fields();
+
+  public static native @Cast("const google::protobuf::Descriptor*") Pointer descriptor();
+  public static native @Const @ByRef TypeProto_Map default_instance();
+
+  public static native void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  public static native @Const TypeProto_Map internal_default_instance();
+  @MemberGetter public static native int kIndexInFileMessages();
+  public static final int kIndexInFileMessages = kIndexInFileMessages();
+
+  public native void Swap(TypeProto_Map other);
+  
+
+  // implements Message ----------------------------------------------
+
+  public native TypeProto_Map New();
+
+  public native TypeProto_Map New(Arena arena);
+  public native void CopyFrom(@Cast("const google::protobuf::Message*") @ByRef MessageLite from);
+  public native void MergeFrom(@Cast("const google::protobuf::Message*") @ByRef MessageLite from);
+  public native void CopyFrom(@Const @ByRef TypeProto_Map from);
+  public native void MergeFrom(@Const @ByRef TypeProto_Map from);
+  public native void Clear();
+  public native @Cast("bool") boolean IsInitialized();
+
+  public native @Cast("size_t") long ByteSizeLong();
+  public native @Cast("bool") boolean MergePartialFromCodedStream(
+        CodedInputStream input);
+  public native void SerializeWithCachedSizes(
+        CodedOutputStream output);
+  public native @Cast("google::protobuf::uint8*") BytePointer InternalSerializeWithCachedSizesToArray(
+        @Cast("bool") boolean deterministic, @Cast("google::protobuf::uint8*") BytePointer target);
+  public native @Cast("google::protobuf::uint8*") ByteBuffer InternalSerializeWithCachedSizesToArray(
+        @Cast("bool") boolean deterministic, @Cast("google::protobuf::uint8*") ByteBuffer target);
+  public native @Cast("google::protobuf::uint8*") byte[] InternalSerializeWithCachedSizesToArray(
+        @Cast("bool") boolean deterministic, @Cast("google::protobuf::uint8*") byte[] target);
+  public native int GetCachedSize();
+
+  public native @ByVal @Cast("google::protobuf::Metadata*") Pointer GetMetadata();
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional .onnx.TypeProto value_type = 2;
+  public native @Cast("bool") boolean has_value_type();
+  public native void clear_value_type();
+  @MemberGetter public static native int kValueTypeFieldNumber();
+  public static final int kValueTypeFieldNumber = kValueTypeFieldNumber();
+  public native @Const @ByRef TypeProto value_type();
+  public native TypeProto release_value_type();
+  public native TypeProto mutable_value_type();
+  public native void set_allocated_value_type(TypeProto value_type);
+
+  // optional .onnx.TensorProto.DataType key_type = 1;
+  public native @Cast("bool") boolean has_key_type();
+  public native void clear_key_type();
+  @MemberGetter public static native int kKeyTypeFieldNumber();
+  public static final int kKeyTypeFieldNumber = kKeyTypeFieldNumber();
+  public native @Cast("onnx::TensorProto_DataType") int key_type();
+  public native void set_key_type(@Cast("onnx::TensorProto_DataType") int value);
+}
+// -------------------------------------------------------------------
+
 @Namespace("onnx") @NoOffset public static class TypeProto extends MessageLite {
     static { Loader.load(); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
@@ -4454,6 +4774,8 @@ public static final int
   /** enum onnx::TypeProto::ValueCase */
   public static final int
     kTensorType = 1,
+    kSequenceType = 4,
+    kMapType = 5,
     VALUE_NOT_SET = 0;
 
   public static native void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
@@ -4520,6 +4842,26 @@ public static final int
   public native TypeProto_Tensor release_tensor_type();
   public native TypeProto_Tensor mutable_tensor_type();
   public native void set_allocated_tensor_type(TypeProto_Tensor tensor_type);
+
+  // optional .onnx.TypeProto.Sequence sequence_type = 4;
+  public native @Cast("bool") boolean has_sequence_type();
+  public native void clear_sequence_type();
+  @MemberGetter public static native int kSequenceTypeFieldNumber();
+  public static final int kSequenceTypeFieldNumber = kSequenceTypeFieldNumber();
+  public native @Const @ByRef TypeProto_Sequence sequence_type();
+  public native TypeProto_Sequence release_sequence_type();
+  public native TypeProto_Sequence mutable_sequence_type();
+  public native void set_allocated_sequence_type(TypeProto_Sequence sequence_type);
+
+  // optional .onnx.TypeProto.Map map_type = 5;
+  public native @Cast("bool") boolean has_map_type();
+  public native void clear_map_type();
+  @MemberGetter public static native int kMapTypeFieldNumber();
+  public static final int kMapTypeFieldNumber = kMapTypeFieldNumber();
+  public native @Const @ByRef TypeProto_Map map_type();
+  public native TypeProto_Map release_map_type();
+  public native TypeProto_Map mutable_map_type();
+  public native void set_allocated_map_type(TypeProto_Map map_type);
 
   public native @Cast("onnx::TypeProto::ValueCase") int value_case();
 }
@@ -5431,9 +5773,61 @@ public static final int
 
 // -------------------------------------------------------------------
 
+// TypeProto_Sequence
+
+// optional .onnx.TypeProto elem_type = 1;
+
+
+
+
+
+
+
+
+
+// -------------------------------------------------------------------
+
+// TypeProto_Map
+
+// optional .onnx.TensorProto.DataType key_type = 1;
+
+
+
+
+
+
+
+// optional .onnx.TypeProto value_type = 2;
+
+
+
+
+
+
+
+
+
+// -------------------------------------------------------------------
+
 // TypeProto
 
 // optional .onnx.TypeProto.Tensor tensor_type = 1;
+
+
+
+
+
+
+
+// optional .onnx.TypeProto.Sequence sequence_type = 4;
+
+
+
+
+
+
+
+// optional .onnx.TypeProto.Map map_type = 5;
 
 
 
@@ -5515,6 +5909,10 @@ public static final int
 
 // -------------------------------------------------------------------
 
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 
 // @@protoc_insertion_point(namespace_scope)
 
@@ -5528,7 +5926,7 @@ public static final int
 
 // @@protoc_insertion_point(global_scope)
 
-// #endif  // PROTOBUF_onnx_2eproto__INCLUDED
+// #endif  // PROTOBUF_onnx_2dml_2eproto__INCLUDED
 
 
 // Parsed from google/protobuf/message_lite.h

--- a/onnx/src/main/java/org/bytedeco/javacpp/presets/onnx.java
+++ b/onnx/src/main/java/org/bytedeco/javacpp/presets/onnx.java
@@ -40,6 +40,7 @@ import java.lang.annotation.Target;
     compiler = "cpp11",
     include = {
         "onnx/defs/schema.h",
+        "onnx/defs/operator_sets.h",
         "onnx/defs/operator_sets-ml.h",
         "onnx/defs/data_type_utils.h",
         "onnx/defs/shape_inference.h",

--- a/onnx/src/main/java/org/bytedeco/javacpp/presets/onnx.java
+++ b/onnx/src/main/java/org/bytedeco/javacpp/presets/onnx.java
@@ -36,14 +36,16 @@ import java.lang.annotation.Target;
 
 @Properties(target = "org.bytedeco.javacpp.onnx", value = @Platform(
     value = "linux-x86_64",
-    define = {"ONNX_NAMESPACE onnx", "ONNX_USE_LITE_PROTO"},
+    define = {"ONNX_NAMESPACE onnx", "ONNX_USE_LITE_PROTO", "ONNX_ML 1"},
     compiler = "cpp11",
     include = {
         "onnx/defs/schema.h",
+//	"onnx/defs/operator_sets.h",
+	"onnx/defs/operator_sets-ml.h",
         "onnx/defs/data_type_utils.h",
         "onnx/defs/shape_inference.h",
-        "onnx/onnx-operators.pb.h",
-        "onnx/onnx.pb.h",
+        "onnx/onnx-operators-ml.pb.h",
+        "onnx/onnx-ml.pb.h",
         "google/protobuf/message_lite.h",
         "google/protobuf/unknown_field_set.h",
         "onnx/proto_utils.h",
@@ -63,10 +65,10 @@ public class onnx implements InfoMapper {
                .put(new Info("std::vector<int64_t>").pointerTypes("LongVector").define())
                .put(new Info("std::vector<std::string>").pointerTypes("StringVector").define())
                .put(new Info("std::initializer_list").skip())
+               .put(new Info("std::function<void(OpSchema&&)>").skip())
                .put(new Info("std::set<int>").pointerTypes("IntSet").define())
                .put(new Info("std::unordered_set<std::string>").pointerTypes("StringSet").define())
                .put(new Info("std::runtime_error").cast().pointerTypes("Pointer"))
-
                .put(new Info("google::protobuf::int8", "google::protobuf::uint8").cast().valueTypes("byte").pointerTypes("BytePointer", "ByteBuffer", "byte[]"))
                .put(new Info("google::protobuf::int16", "google::protobuf::uint16").cast().valueTypes("short").pointerTypes("ShortPointer", "ShortBuffer", "short[]"))
                .put(new Info("google::protobuf::int32", "google::protobuf::uint32").cast().valueTypes("int").pointerTypes("IntPointer", "IntBuffer", "int[]"))
@@ -79,6 +81,7 @@ public class onnx implements InfoMapper {
                              "google::protobuf::internal::AuxillaryParseTableField", "google::protobuf::internal::ParseTableField", "google::protobuf::internal::ParseTable",
                              "google::protobuf::internal::FieldMetadata", "google::protobuf::internal::SerializationTable", "google::protobuf::internal::proto3_preserve_unknown_",
                              "google::protobuf::is_proto_enum", "google::protobuf::GetEnumDescriptor", "google::protobuf::RepeatedField", "onnx::_TypeProto_default_instance_",
+                             "onnx::_TypeProto_Map_default_instance_", "onnx::_TypeProto_Sequence_default_instance_",
                              "onnx::_TypeProto_Tensor_default_instance_",  "onnx::_ValueInfoProto_default_instance_", "onnx::_TensorShapeProto_Dimension_default_instance_",
                              "onnx::_TensorShapeProto_default_instance_", "onnx::_TensorProto_Segment_default_instance_","onnx::_TensorProto_default_instance_",
                              "onnx::_NodeProto_default_instance_", "onnx::_GraphProto_default_instance_", "onnx::_FunctionProto_default_instance_", "onnx::_ModelProto_default_instance_", "onnx::_OperatorSetProto_default_instance_",
@@ -89,7 +92,6 @@ public class onnx implements InfoMapper {
                .put(new Info("onnx::OpSchema::Attribute").pointerTypes("OpSchema.Attribute"))
                .put(new Info("onnx::OpSchema::FormalParameter").pointerTypes("OpSchema.FormalParameter"))
                .put(new Info("onnx::OpSchema::TypeConstraintParam").pointerTypes("OpSchema.TypeConstraintParam"))
-
                .put(new Info("std::pair<int,int>", "std::pair<onnx::OpSchema::UseType,int>").pointerTypes("UseTypeIntPair").define())
                .put(new Info("const std::map<std::string,onnx::OpSchema::Attribute>").pointerTypes("StringAttributeMap").define())
                .put(new Info("std::unordered_map<std::string,int>").pointerTypes("StringIntMap").define())

--- a/onnx/src/main/java/org/bytedeco/javacpp/presets/onnx.java
+++ b/onnx/src/main/java/org/bytedeco/javacpp/presets/onnx.java
@@ -40,8 +40,7 @@ import java.lang.annotation.Target;
     compiler = "cpp11",
     include = {
         "onnx/defs/schema.h",
-//	"onnx/defs/operator_sets.h",
-	"onnx/defs/operator_sets-ml.h",
+        "onnx/defs/operator_sets-ml.h",
         "onnx/defs/data_type_utils.h",
         "onnx/defs/shape_inference.h",
         "onnx/onnx-operators-ml.pb.h",
@@ -64,11 +63,11 @@ public class onnx implements InfoMapper {
                .put(new Info("std::vector<float>").pointerTypes("FloatVector").define())
                .put(new Info("std::vector<int64_t>").pointerTypes("LongVector").define())
                .put(new Info("std::vector<std::string>").pointerTypes("StringVector").define())
-               .put(new Info("std::initializer_list").skip())
-               .put(new Info("std::function<void(OpSchema&&)>").skip())
+               .put(new Info("std::initializer_list", "std::function<void(OpSchema&&)>").skip())
                .put(new Info("std::set<int>").pointerTypes("IntSet").define())
                .put(new Info("std::unordered_set<std::string>").pointerTypes("StringSet").define())
                .put(new Info("std::runtime_error").cast().pointerTypes("Pointer"))
+
                .put(new Info("google::protobuf::int8", "google::protobuf::uint8").cast().valueTypes("byte").pointerTypes("BytePointer", "ByteBuffer", "byte[]"))
                .put(new Info("google::protobuf::int16", "google::protobuf::uint16").cast().valueTypes("short").pointerTypes("ShortPointer", "ShortBuffer", "short[]"))
                .put(new Info("google::protobuf::int32", "google::protobuf::uint32").cast().valueTypes("int").pointerTypes("IntPointer", "IntBuffer", "int[]"))
@@ -92,6 +91,7 @@ public class onnx implements InfoMapper {
                .put(new Info("onnx::OpSchema::Attribute").pointerTypes("OpSchema.Attribute"))
                .put(new Info("onnx::OpSchema::FormalParameter").pointerTypes("OpSchema.FormalParameter"))
                .put(new Info("onnx::OpSchema::TypeConstraintParam").pointerTypes("OpSchema.TypeConstraintParam"))
+
                .put(new Info("std::pair<int,int>", "std::pair<onnx::OpSchema::UseType,int>").pointerTypes("UseTypeIntPair").define())
                .put(new Info("const std::map<std::string,onnx::OpSchema::Attribute>").pointerTypes("StringAttributeMap").define())
                .put(new Info("std::unordered_map<std::string,int>").pointerTypes("StringIntMap").define())


### PR DESCRIPTION
This builds without error, but it still doesn't return the Traditional ML ops on call ```org.bytedeco.javacpp.onnx.OpSchemaRegistry.get_all_schemas()```.
It returns 115 ops, whereas doing the same thing in python returns 133.

Digging in a bit more, calling `org.bytedeco.javacpp.onnx.RegisterOnnxMLOperatorSetSchema()` 
results in:

`java.lang.UnsatisfiedLinkError: org.bytedeco.javacpp.onnx.RegisterOnnxMLOperatorSetSchema()V
  at org.bytedeco.javacpp.onnx.RegisterOnnxMLOperatorSetSchema(Native Method)`

Which is strange, since we already link to both of the .so files the ONNX build produces.

I think the root cause is again the rvalue thing, specifically this line in schema.h : ```void RegisterSchema(OpSchema&& schema)```.
Is it possible to apply `std::move` to get the rvalue?

Any ideas?