### PR TITLE
Disable `ARCH_OPT_FLAGS` in mkl-dnn

### DIFF
--- a/mkl-dnn/cppbuild.sh
+++ b/mkl-dnn/cppbuild.sh
@@ -27,7 +27,7 @@ case $PLATFORM in
         mkdir -p external
         tar --totals -xf mklml_lnx_$MKLML_VERSION.tgz -C external
         # libmklml_intel.so does not have a SONAME, so libmkldnn.so.0 needs an RPATH to be able to load
-        "$CMAKE" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_CXX_FLAGS='-Wl,-rpath,$ORIGIN/' -Wno-error=unused-result
+        "$CMAKE" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_CXX_FLAGS='-Wl,-rpath,$ORIGIN/' -DARCH_OPT_FLAGS='' -Wno-error=unused-result
         make -j $MAKEJ
         make install/strip
         cp external/mklml_lnx_$MKLML_VERSION/include/* ../include/
@@ -39,7 +39,7 @@ case $PLATFORM in
         export CC="$(ls -1 /usr/local/bin/gcc-? | head -n 1)"
         export CXX="$(ls -1 /usr/local/bin/g++-? | head -n 1)"
         sedinplace 's/__thread/thread_local/g' src/common/utils.hpp
-        "$CMAKE" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+        "$CMAKE" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DARCH_OPT_FLAGS=''
         make -j $MAKEJ
         make install/strip
         cp external/mklml_mac_$MKLML_VERSION/include/* ../include/
@@ -50,7 +50,7 @@ case $PLATFORM in
         download https://github.com/intel/mkl-dnn/releases/download/v$MKLDNN_VERSION/mklml_win_$MKLML_VERSION.zip mklml_win_$MKLML_VERSION.zip
         mkdir -p external
         unzip -o mklml_win_$MKLML_VERSION.zip -d external
-        "$CMAKE" -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+        "$CMAKE" -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DARCH_OPT_FLAGS=''
         make -j $MAKEJ
         make install/strip
         cp external/mklml_win_$MKLML_VERSION/include/* ../include/


### PR DESCRIPTION
At least v0.16, MKL-DNN try to enable `-march=native -mtune=native` when `-DARCH_OPT_FLAGS` is not specified ([ref](https://github.com/intel/mkl-dnn/blob/a147082ce98243af386cc7d6498fb6ab11fb98ee/cmake/options.cmake#L53-L71)):

```
set(ARCH_OPT_FLAGS "HostOpts" CACHE STRING
    "specifies compiler optimization flags (see below for more information).
    If empty default optimization level would be applied which depends on the
    compiler being used.

    - For Intel(R) C++ Compilers the default option is `-xHOST` which instructs
      the compiler to generate the code for the architecture where building is
      happening. This option would not allow to run the library on older
      architectures.

    - For GNU* Compiler Collection version 5 and newer the default options are
      `-march=native -mtune=native` which behaves similarly to the descriprion
      above.

    - For all other cases there are no special optimizations flags.

    If the library is to be built for generic architecture (e.g. built by a
    Linux distributive maintainer) one may want to specify ARCH_OPT_FLAGS=\"\"
    to not use any host specific instructions")
```

It has a chance to fail when you build and distribute the mkl-dnn binary. For example, GCC generates newer CPU instructions supported by the detected processors even if `as` (assembler) in older `binutils` in your machine doesn't support them ([ref](https://github.com/opencv/opencv/issues/11120)):

```
# make
[  1%] Building CXX object src/CMakeFiles/mkldnn.dir/common/batch_normalization.cpp.o
/tmp/ccs0bO1c.s: Assembler messages:
/tmp/ccs0bO1c.s:211: Error: suffix or operands invalid for `vpsrlq'
/tmp/ccs0bO1c.s:212: Error: suffix or operands invalid for `vpmovsxdq'
/tmp/ccs0bO1c.s:213: Error: no such instruction: `vextracti128 $0x1,%ymm2,%xmm2'
/tmp/ccs0bO1c.s:214: Error: suffix or operands invalid for `vpmuludq'
/tmp/ccs0bO1c.s:215: Error: suffix or operands invalid for `vpsrlq'
/tmp/ccs0bO1c.s:216: Error: suffix or operands invalid for `vpmuludq'
/tmp/ccs0bO1c.s:217: Error: suffix or operands invalid for `vpmovsxdq'
...
```

It might be a problem especially for building the mkl-dnn binary on virtualized machines because we can't specify which processor is used.
