### PR TITLE
Add support for linux-mips64el to OpenCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ With the above in working order, the scripts get launched automatically as part 
 ```bash
 $ ANDROID_NDK=/path/to/android-ndk/ bash cppbuild.sh [-platform <name>] <install | clean> [projects]
 ```
-where possible platform names are: `android-arm`, `android-x86`, `linux-x86`, `linux-x86_64`, `linux-armhf`, `linux-ppc64le` `macosx-x86_64`, `windows-x86`, `windows-x86_64`, etc. (The `ANDROID_NDK` variable is required only for Android builds.) Please note that the scripts download source archives from appropriate sites as necessary.
+where possible platform names are: `android-arm`, `android-x86`, `linux-x86`, `linux-x86_64`, `linux-armhf`, `linux-ppc64le`, `linux-mips64el`, `macosx-x86_64`, `windows-x86`, `windows-x86_64`, etc. (The `ANDROID_NDK` variable is required only for Android builds.) Please note that the scripts download source archives from appropriate sites as necessary.
 
 To compile binaries for an Android device with no FPU, first make sure this is what you want. Without FPU, the performance of either OpenCV or FFmpeg is bound to be unacceptable. If you still wish to continue down that road, then replace "armeabi-v7a" by "armeabi" and "-march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16" with "-march=armv5te -mtune=xscale -msoft-float", inside various files.
 

--- a/opencv/cppbuild.sh
+++ b/opencv/cppbuild.sh
@@ -157,6 +157,13 @@ case $PLATFORM in
         cp ../share/OpenCV/java/libopencv_java.so ../lib
         sedinplace "s/.so.$OPENCV_VERSION/.so/g" ../share/OpenCV/OpenCVModules-release.cmake
         ;;
+    linux-mips64el)
+        CC="gcc -mabi=64" CXX="g++ -mabi=64" $CMAKE -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH" -DCMAKE_INSTALL_LIBDIR="lib" $BUILD_X -DENABLE_PRECOMPILED_HEADERS=OFF $WITH_X -DWITH_OPENMP=ON $GPU_FLAGS -DCUDA_HOST_COMPILER=/usr/bin/g++ -DWITH_IPP=OFF $BUILD_CONTRIB_X
+        make -j $MAKEJ
+        make install/strip
+        cp ../share/OpenCV/java/libopencv_java.so ../lib
+        sedinplace "s/.so.$OPENCV_VERSION/.so/g" ../share/OpenCV/OpenCVModules-release.cmake
+        ;;
     macosx-*)
         $CMAKE -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH" -DCMAKE_INSTALL_LIBDIR="lib" $BUILD_X -DENABLE_PRECOMPILED_HEADERS=OFF $WITH_X -DWITH_OPENMP=OFF $GPU_FLAGS -DCUDA_HOST_COMPILER=/usr/bin/clang++ -DWITH_IPP=OFF $BUILD_CONTRIB_X -DCMAKE_CXX_FLAGS="-w"
         make -j $MAKEJ


### PR DESCRIPTION
Built on Loongson 3A3000 CPUs, which are little-endian MIPS64.
OS: Loongnix (based on Fedora 21, http://www.loongnix.org)
gcc: 4.9.3
glibc: 2.20
jdk: OpenJDK 8 ported by loongson (http://ftp.loongnix.org/toolchain/java/openjdk8/jdk8-mips64-8.tar.gz)