### PR TITLE
Add build for `linux-mips64el` to presets for ARToolKitPlus

### DIFF
--- a/artoolkitplus/cppbuild.sh
+++ b/artoolkitplus/cppbuild.sh
@@ -63,6 +63,11 @@ case $PLATFORM in
         make -j4
         make install
         ;;
+    linux-mips64el)
+        CC="$OLDCC -mabi=64" CXX="$OLDCXX -mabi=64" $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=..
+        make -j4
+        make install
+        ;;
     macosx-*)
         $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=..
         make -j4


### PR DESCRIPTION
Built on Loongson 3A3000 CPUs, which are little-endian MIPS64.
OS: Debian stable (9)
gcc: 6.3.0
glibc: 2.24
jdk: OpenJDK 8 ported by Loongson