### PR TITLE
Add build for `linux-mips64el` to presets for Chilitags

### DIFF
--- a/chilitags/cppbuild.sh
+++ b/chilitags/cppbuild.sh
@@ -76,6 +76,11 @@ case $PLATFORM in
         make -j4
         make install
         ;;
+    linux-mips64el)
+        CXX="g++ -mabi=64 -fPIC" $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
+        make -j4
+        make install
+        ;;
     macosx-*)
         CXX="clang++ -fPIC" $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
         make -j4


### PR DESCRIPTION
Built on Loongson 3A3000 CPUs, which are little-endian MIPS64.
OS: Debian stable (9)
gcc: 6.3.0
glibc: 2.24
jdk: OpenJDK 8 ported by Loongson