### PR TITLE
Add build for `linux-mips64el` to presets for FFTW

### DIFF
--- a/fftw/cppbuild.sh
+++ b/fftw/cppbuild.sh
@@ -132,6 +132,14 @@ case $PLATFORM in
           make install-strip
         fi
         ;;
+    linux-mips64el)
+        ./configure --prefix=$INSTALL_PATH --disable-fortran --enable-shared --enable-threads --with-combined-threads CC="$OLDCC -mabi=64"
+        make -j $MAKEJ V=0
+        make install-strip
+        ./configure --prefix=$INSTALL_PATH --disable-fortran --enable-shared --enable-threads --with-combined-threads CC="$OLDCC -mabi=64" --enable-float
+        make -j $MAKEJ V=0
+        make install-strip
+        ;;
     macosx-*)
         patch -Np1 < ../../../fftw-macosx.patch
         ./configure --prefix=$INSTALL_PATH --disable-fortran --enable-shared --enable-threads --with-combined-threads --enable-sse2


### PR DESCRIPTION
Built on Loongson 3A3000 CPUs, which are little-endian MIPS64.
OS: Debian stable (9)
gcc: 6.3.0
glibc: 2.24
jdk: OpenJDK 8 ported by Loongson