### PR TITLE
Add build for `linux-mips64el` to presets for flandmark

### DIFF
--- a/flandmark/cppbuild.sh
+++ b/flandmark/cppbuild.sh
@@ -85,6 +85,12 @@ case $PLATFORM in
         cp libflandmark/*.h ../include
         cp libflandmark/*.a ../lib
         ;;
+    linux-mips64el)
+        CC="$OLDCC -mabi=64" CXX="$OLDCXX -mabi=64" $CMAKE -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
+        make -j4 flandmark_static
+        cp libflandmark/*.h ../include
+        cp libflandmark/*.a ../lib
+        ;;
     macosx-*)
         CXX="g++ -fpermissive" $CMAKE -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
         make -j4 flandmark_static


### PR DESCRIPTION
Built on Loongson 3A3000 CPUs, which are little-endian MIPS64.
OS: Debian stable (9)
gcc: 6.3.0
glibc: 2.24
jdk: OpenJDK 8 ported by Loongson