### PR TITLE
Add build for `linux-mips64el` to presets for OpenBLAS

### DIFF
--- a/openblas/cppbuild.sh
+++ b/openblas/cppbuild.sh
@@ -159,6 +159,13 @@ case $PLATFORM in
         export BINARY=64
         export TARGET=POWER5
         ;;
+    linux-mips64el)
+        export CC="$OLDCC -mabi=64"
+        export FC="$OLDFC -mabi=64"
+        export LDFLAGS="-Wl,-z,noexecstack"
+        export BINARY=64
+        export TARGET=MIPS
+        ;;
     linux-armhf)
         export CC="arm-linux-gnueabihf-gcc"
         export FC="arm-linux-gnueabihf-gfortran"


### PR DESCRIPTION
Built on Loongson 3A3000 CPUs, which are little-endian MIPS64.
OS: Debian stable (9)
gcc: 6.3.0
glibc: 2.24
jdk: OpenJDK 8 ported by Loongson