### PR TITLE
Add build for `linux-mips64el` to presets for ARToolKitPlus, Chilitags, FFTW, flandmark and OpenBLAS.

### DIFF
--- a/artoolkitplus/cppbuild.sh
+++ b/artoolkitplus/cppbuild.sh
@@ -63,6 +63,11 @@ case $PLATFORM in
         make -j4
         make install
         ;;
+    linux-mips64el)
+        CC="$OLDCC -mabi=64" CXX="$OLDCXX -mabi=64" $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=..
+        make -j4
+        make install
+        ;;
     macosx-*)
         $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=..
         make -j4

--- a/chilitags/cppbuild.sh
+++ b/chilitags/cppbuild.sh
@@ -76,6 +76,11 @@ case $PLATFORM in
         make -j4
         make install
         ;;
+    linux-mips64el)
+        CXX="g++ -mabi=64 -fPIC" $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
+        make -j4
+        make install
+        ;;
     macosx-*)
         CXX="clang++ -fPIC" $CMAKE -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.. -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
         make -j4

--- a/fftw/cppbuild.sh
+++ b/fftw/cppbuild.sh
@@ -132,6 +132,14 @@ case $PLATFORM in
           make install-strip
         fi
         ;;
+    linux-mips64el)
+        ./configure --prefix=$INSTALL_PATH --disable-fortran --enable-shared --enable-threads --with-combined-threads CC="$OLDCC -mabi=64"
+        make -j $MAKEJ V=0
+        make install-strip
+        ./configure --prefix=$INSTALL_PATH --disable-fortran --enable-shared --enable-threads --with-combined-threads CC="$OLDCC -mabi=64" --enable-float
+        make -j $MAKEJ V=0
+        make install-strip
+        ;;
     macosx-*)
         patch -Np1 < ../../../fftw-macosx.patch
         ./configure --prefix=$INSTALL_PATH --disable-fortran --enable-shared --enable-threads --with-combined-threads --enable-sse2

--- a/flandmark/cppbuild.sh
+++ b/flandmark/cppbuild.sh
@@ -85,6 +85,12 @@ case $PLATFORM in
         cp libflandmark/*.h ../include
         cp libflandmark/*.a ../lib
         ;;
+    linux-mips64el)
+        CC="$OLDCC -mabi=64" CXX="$OLDCXX -mabi=64" $CMAKE -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
+        make -j4 flandmark_static
+        cp libflandmark/*.h ../include
+        cp libflandmark/*.a ../lib
+        ;;
     macosx-*)
         CXX="g++ -fpermissive" $CMAKE -DCMAKE_BUILD_TYPE=Release -DOpenCV_DIR=$OPENCV_PATH/share/OpenCV/
         make -j4 flandmark_static

--- a/openblas/cppbuild.sh
+++ b/openblas/cppbuild.sh
@@ -159,6 +159,13 @@ case $PLATFORM in
         export BINARY=64
         export TARGET=POWER5
         ;;
+    linux-mips64el)
+        export CC="$OLDCC -mabi=64"
+        export FC="$OLDFC -mabi=64"
+        export LDFLAGS="-Wl,-z,noexecstack"
+        export BINARY=64
+        export TARGET=MIPS
+        ;;
     linux-armhf)
         export CC="arm-linux-gnueabihf-gcc"
         export FC="arm-linux-gnueabihf-gfortran"


### PR DESCRIPTION
Add build for `linux-mips64el` to presets for ARToolKitPlus, Chilitags, FFTW, flandmark and OpenBLAS.
Put pull rerequests (#631 #632 #633 #634 #635) into one.