### PR TITLE
OpenCV: Added support for nD to AbstractMat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add support for N-dimensional arrays to `opencv_core.Mat.createIndexer()` ([pull #647](https://github.com/bytedeco/javacpp-presets/pull/647))
  * Add a `PIX.create(..., Pointer data)` helper factory method that prevents premature deallocation ([issue bytedeco/javacpp#272](https://github.com/bytedeco/javacpp/issues/272))
  * Enable x265 multilib depth support at 8, 10, and 12 bits for FFmpeg ([pull #619](https://github.com/bytedeco/javacpp-presets/pull/619))
  * Include all header files from `Python.h` in presets for CPython

--- a/opencv/src/main/java/org/bytedeco/javacpp/helper/opencv_core.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/helper/opencv_core.java
@@ -104,20 +104,6 @@ import static org.bytedeco.javacpp.opencv_core.cvScalar;
 
 public class opencv_core extends org.bytedeco.javacpp.presets.opencv_core {
 
-    public static int CV_ELEM_SIZE1(int type) {
-        switch (type & CV_MAT_DEPTH_MASK) {
-            case CV_8U:
-            case CV_8S:  return 1;
-            case CV_16U:
-            case CV_16S: return 2;
-            case CV_32S:
-            case CV_32F: return 4;
-            case CV_64F: return 8;
-            default: assert false;
-        }
-        return 0;
-    }
-
     public static abstract class AbstractArray extends Pointer implements Indexable {
         static { Loader.load(); }
         public AbstractArray(Pointer p) { super(p); }
@@ -1818,6 +1804,7 @@ public class opencv_core extends org.bytedeco.javacpp.presets.opencv_core {
         public abstract int size(int i);
         public abstract int step(int i);
         public abstract int dims();
+        public abstract long elemSize1();
 
         @Override public int arrayChannels() { return channels(); }
         @Override public int arrayDepth() {
@@ -1849,7 +1836,7 @@ public class opencv_core extends org.bytedeco.javacpp.presets.opencv_core {
             int size = arraySize();
             int dims = dims();
             int depth = depth();
-            int elemSize = CV_ELEM_SIZE1(depth);
+            long elemSize = elemSize1();
 
             long[] sizes = new long[dims+1];
             long[] strides = new long[dims+1];

--- a/opencv/src/main/java/org/bytedeco/javacpp/helper/opencv_core.java
+++ b/opencv/src/main/java/org/bytedeco/javacpp/helper/opencv_core.java
@@ -64,7 +64,6 @@ import static org.bytedeco.javacpp.opencv_core.CV_L2;
 import static org.bytedeco.javacpp.opencv_core.CV_MAKETYPE;
 import static org.bytedeco.javacpp.opencv_core.CV_MAT_CN;
 import static org.bytedeco.javacpp.opencv_core.CV_MAT_DEPTH;
-import static org.bytedeco.javacpp.opencv_core.CV_MAT_DEPTH_MASK;
 import static org.bytedeco.javacpp.opencv_core.CV_MAT_MAGIC_VAL;
 import static org.bytedeco.javacpp.opencv_core.CV_MAT_TYPE;
 import static org.bytedeco.javacpp.opencv_core.IPL_DEPTH_16S;
@@ -93,6 +92,8 @@ import static org.bytedeco.javacpp.opencv_core.cvCreateSparseMat;
 import static org.bytedeco.javacpp.opencv_core.cvGet2D;
 import static org.bytedeco.javacpp.opencv_core.cvGetImage;
 import static org.bytedeco.javacpp.opencv_core.cvGetMat;
+//import static org.bytedeco.javacpp.opencv_core.cvOpenFileStorage;
+//import static org.bytedeco.javacpp.opencv_core.cvReleaseFileStorage;
 import static org.bytedeco.javacpp.opencv_core.cvReleaseGraphScanner;
 import static org.bytedeco.javacpp.opencv_core.cvReleaseImage;
 import static org.bytedeco.javacpp.opencv_core.cvReleaseImageHeader;
@@ -1844,8 +1845,9 @@ public class opencv_core extends org.bytedeco.javacpp.presets.opencv_core {
             for (int i=0; i<dims; i++) {
                 sizes[i] = size(i);
                 int step = step(i);
-                if (step%elemSize != 0)
-                  throw new UnsupportedOperationException("Step is not a multiple of element size");
+                if (step%elemSize != 0) {
+                    throw new UnsupportedOperationException("Step is not a multiple of element size");
+                }
                 strides[i] = step/elemSize;
             }
             sizes[dims] = arrayChannels();


### PR DESCRIPTION
AbstractArray.createIndexer doesn't support Mat with more than 2 dimensions.
Added AbstractMat.createIndexer that does.
The channels are considered as an additional dimension in the indexer, but this dimension
can be omitted in a long[] array of indices for mats with only 1 channel.
One limitation : Mat theoretically accepts steps that are not multiple of the element size, but indexer does not. An exception is thrown by createIndexer if this occurs.
In JavaCPP, Indexer.rows, cols, width, heads, channels should also be deprecated or modified to return -1 if the number of dimensions of the indexer is not 3.