### PR TITLE
Set compile source roots using build-helper plugin

### DIFF
--- a/opencv/pom.xml
+++ b/opencv/pom.xml
@@ -101,6 +101,10 @@
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
       </plugin>

--- a/opencv/pom.xml
+++ b/opencv/pom.xml
@@ -45,6 +45,10 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.bytedeco</groupId>
         <artifactId>javacpp</artifactId>
       </plugin>
@@ -99,10 +103,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.moditect</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,26 +143,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-          </execution>
-        </executions>
-            <configuration>
-              <sources>
-                <source>${project.basedir}/src/gen/java</source>
-                <source>${project.basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/java/</source>
-              </sources>
-            </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
@@ -184,6 +164,26 @@
                 <include>org/bytedeco/javacpp/**/*_presets.java</include>
               </includes>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <sources>
+            <source>${project.basedir}/src/gen/java</source>
+            <source>${project.basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/java/</source>
+          </sources>
+        </configuration>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <executions>
           <execution>
             <id>add-source</id>
-            <phase>generate-sources</phase>
+            <phase>process-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,26 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+          </execution>
+        </executions>
+            <configuration>
+              <sources>
+                <source>${project.basedir}/src/gen/java</source>
+                <source>${project.basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/java/</source>
+              </sources>
+            </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
@@ -152,13 +172,6 @@
         <executions>
           <execution>
             <id>default-compile</id>
-            <configuration>
-              <compileSourceRoots>
-                <compileSourceRoot>${project.build.sourceDirectory}</compileSourceRoot>
-                <compileSourceRoot>${project.basedir}/src/gen/java</compileSourceRoot>
-                <compileSourceRoot>${project.basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/java/</compileSourceRoot>
-              </compileSourceRoots>
-            </configuration>
           </execution>
           <execution>
             <id>javacpp.parser</id>
@@ -438,7 +451,6 @@
             <configuration>
               <minmemory>128m</minmemory>
               <maxmemory>1024m</maxmemory>
-              <sourcepath>${project.build.sourceDirectory}:${project.basedir}/src/gen/java:${project.basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/java/</sourcepath>
               <links>
                 <link>http://bytedeco.org/javacpp/apidocs</link>
               </links>


### PR DESCRIPTION
Currently, the pom uses `<compileSourceRoots>` in the configuration of the default execution of the maven compiler to add the generated sources and the possible java sources included in the library distribution.
This configuration seems to remain local to the compiler and is not used by the javadoc and maven-source plugins.
I suggest to replace this (quite undocumented) config by the use of the `add-source` goal of `build-helper-maven-plugin`.
This is yet another plugin to add to each pom, but it seems cleaner and prevent the reconfiguration of the source paths for javadoc and maven-source.
