### PR TITLE
Replace jar GAV by jar filename in moditect config

### DIFF
--- a/cuda/pom.xml
+++ b/cuda/pom.xml
@@ -81,12 +81,7 @@
             <configuration>
               <modules>
                 <module>
-                  <artifact>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${project.artifactId}</artifactId>
-                    <version>${project.version}</version>
-                    <classifier>${javacpp.platform}-redist</classifier>
-                  </artifact>
+                  <file>${project.build.directory}/${project.artifactId}-${javacpp.platform}-redist.jar</file>
                   <moduleInfoSource>
                     open module org.bytedeco.${javacpp.packageName}.${javacpp.platform.module}.redist {
                       requires transitive org.bytedeco.${javacpp.packageName};

--- a/mkl/pom.xml
+++ b/mkl/pom.xml
@@ -81,12 +81,7 @@
             <configuration>
               <modules>
                 <module>
-                  <artifact>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${project.artifactId}</artifactId>
-                    <version>${project.version}</version>
-                    <classifier>${javacpp.platform}-redist</classifier>
-                  </artifact>
+                  <file>${project.build.directory}/${project.artifactId}-${javacpp.platform}-redist.jar</file>
                   <moduleInfoSource>
                     open module org.bytedeco.${javacpp.packageName}.${javacpp.platform.module}.redist {
                       requires transitive org.bytedeco.${javacpp.packageName};

--- a/pom.xml
+++ b/pom.xml
@@ -347,11 +347,12 @@
             <configuration>
               <classifier>${javacpp.platform}${javacpp.platform.extension}</classifier>
               <skipIfEmpty>true</skipIfEmpty>
-              <!--
-              <includes>
+              <includes> 
+                <!-- In case of successive builds for multiple platforms
+                     without cleaning, ensures we only include files for
+                     this platform. -->
                 <include>${javacpp.platform.nativeOutputPath}/</include>
               </includes>
-              -->
               <archive>
                 <manifestEntries>
                   <Multi-Release>true</Multi-Release>

--- a/pom.xml
+++ b/pom.xml
@@ -347,9 +347,11 @@
             <configuration>
               <classifier>${javacpp.platform}${javacpp.platform.extension}</classifier>
               <skipIfEmpty>true</skipIfEmpty>
+              <!--
               <includes>
                 <include>${javacpp.platform.nativeOutputPath}/</include>
               </includes>
+              -->
               <archive>
                 <manifestEntries>
                   <Multi-Release>true</Multi-Release>
@@ -384,20 +386,11 @@
             <configuration>
               <modules>
                 <module>
-                  <artifact>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${project.artifactId}</artifactId>
-                    <version>${project.version}</version>
-                  </artifact>
+                  <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoFile>${project.basedir}/src/main/java9/module-info.java</moduleInfoFile>
                 </module>
                 <module>
-                  <artifact>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${project.artifactId}</artifactId>
-                    <version>${project.version}</version>
-                    <classifier>${javacpp.platform}${javacpp.platform.extension}</classifier>
-                  </artifact>
+                  <file>${project.build.directory}/${project.artifactId}-${javacpp.platform}${javacpp.platform.extension}.jar</file>
                   <moduleInfoSource>
                     open module org.bytedeco.${javacpp.packageName}.${javacpp.platform.module} {
                       requires transitive org.bytedeco.${javacpp.packageName};


### PR DESCRIPTION
Ensure moditect adds the module-info to the target jar, and not a jar fetched from maven repository.
Also commented out an <include> that seems useless.