### PR TITLE
Comment out requires to android native modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `-platform` artifacts on JPMS by commenting out requires to Android modules ([issue #814](https://github.com/bytedeco/javacpp-presets/issues/814) and ([pull #831](https://github.com/bytedeco/javacpp-presets/pull/831)))
  * Include `timecode.h`, among other missing header files, in the `avutil` module of FFmpeg ([issue #822](https://github.com/bytedeco/javacpp-presets/issues/822))
  * Map a few more inherited constructors missing from the presets for MKL-DNN and DNNL
  * Make sure `clone()` actually returns new `PIX`, `FPIX`, or `DPIX` objects with presets for Leptonica

--- a/artoolkitplus/platform/pom.xml
+++ b/artoolkitplus/platform/pom.xml
@@ -154,10 +154,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/chilitags/platform/pom.xml
+++ b/chilitags/platform/pom.xml
@@ -159,10 +159,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/cpu_features/platform/pom.xml
+++ b/cpu_features/platform/pom.xml
@@ -154,10 +154,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/ffmpeg/platform/pom.xml
+++ b/ffmpeg/platform/pom.xml
@@ -154,10 +154,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/fftw/platform/pom.xml
+++ b/fftw/platform/pom.xml
@@ -154,10 +154,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/flandmark/platform/pom.xml
+++ b/flandmark/platform/pom.xml
@@ -159,10 +159,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/gsl/platform/pom.xml
+++ b/gsl/platform/pom.xml
@@ -159,10 +159,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/leptonica/platform/pom.xml
+++ b/leptonica/platform/pom.xml
@@ -154,10 +154,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;

--- a/openblas/platform/pom.xml
+++ b/openblas/platform/pom.xml
@@ -166,10 +166,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.ios.arm64;
                       requires org.bytedeco.${javacpp.moduleId}.ios.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;

--- a/opencv/platform/pom.xml
+++ b/opencv/platform/pom.xml
@@ -172,10 +172,10 @@
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
                       requires transitive org.bytedeco.${javacpp.moduleId};
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.ios.arm64;
                       requires org.bytedeco.${javacpp.moduleId}.ios.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;

--- a/tensorflow/platform/pom.xml
+++ b/tensorflow/platform/pom.xml
@@ -141,10 +141,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.macosx.x86_64;

--- a/tesseract/platform/pom.xml
+++ b/tesseract/platform/pom.xml
@@ -159,10 +159,10 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
-                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
-                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.arm64;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86;
+//                      requires org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires org.bytedeco.${javacpp.moduleId}.linux.armhf;


### PR DESCRIPTION
Android expects the native library to be installed in `/lib/<abi>` directory.
That's why in the jars of native libraries the libraries are in `/lib/<abi>` instead of the `/org/bytedeco/<presets>/<system>-<abi>/` path used for other platforms.
So when using JPMS and bringing in the module graph the native jars of multiple presets for android, files in directory `/lib/<abi>` are present in multiple modules, leading to a split package exception.
Note that this only happens :
- when using JPMS (so not on Android since Android doesn't support JPMS yet)
- when bringing the native jars for android and for an abi not containing a `-` into the module graph (problably using some `requires org.bytedeco.<preset>.platform` in the application `module-info.java`). Since directories with a `-` are not considered java packages.
 
This PR solves this problem by removing the dependencies of platform modules towards android native modules, so that the android native modules are never brought into the module graph when using the platform modules.
This shouldn't have side effects as long as Android doesn't support JPMS.

See [Issue 814](https://github.com/bytedeco/javacpp-presets/issues/814)