### PR TITLE
Fix various typo in module-info exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix JPMS modules for CUDA, ARPACK-NG, GSL, SciPy, Gym, MXNet ([pull #880](https://github.com/bytedeco/javacpp-presets/pull/880) and [pull #881](https://github.com/bytedeco/javacpp-presets/pull/881))
  * Build OpenBLAS with a `TARGET` even for `DYNAMIC_ARCH` to avoid SIGILL ([issue eclipse/deeplearning4j#8747](https://github.com/eclipse/deeplearning4j/issues/8747))
  * Upgrade presets for Arrow 0.17.0, MKL-DNN 0.21.5, DNNL 1.4, NumPy 1.18.3, and their dependencies
  * Add `FullOptimization.h` allowing users to fully optimize LLVM modules ([pull #869](https://github.com/bytedeco/javacpp-presets/pull/869))

--- a/arpack-ng/src/main/java9/module-info.java
+++ b/arpack-ng/src/main/java9/module-info.java
@@ -2,5 +2,5 @@ module org.bytedeco.arpackng {
   requires transitive org.bytedeco.javacpp;
   requires transitive org.bytedeco.openblas;
   exports org.bytedeco.arpackng.global;
-  exports org.bytedeco.arpacking.presets;
+  exports org.bytedeco.arpackng.presets;
 }

--- a/gsl/src/main/java9/module-info.java
+++ b/gsl/src/main/java9/module-info.java
@@ -2,6 +2,6 @@ module org.bytedeco.gsl {
   requires transitive org.bytedeco.javacpp;
   requires transitive org.bytedeco.openblas;
   exports org.bytedeco.gsl.global;
-  exports org.bytedeco.gls.presets;
+  exports org.bytedeco.gsl.presets;
   exports org.bytedeco.gsl;
 }

--- a/gym/src/main/java9/module-info.java
+++ b/gym/src/main/java9/module-info.java
@@ -1,6 +1,4 @@
 module org.bytedeco.gym {
   requires transitive org.bytedeco.javacpp;
-  exports org.bytedeco.gym.global;
   exports org.bytedeco.gym.presets;
-  exports org.bytedeco.gym;
 }

--- a/mxnet/src/main/java9/module-info.java
+++ b/mxnet/src/main/java9/module-info.java
@@ -23,5 +23,5 @@ module org.bytedeco.mxnet {
   exports org.apache.mxnet.spark.example;
   exports org.apache.mxnet.spark.transformer;
   exports org.apache.mxnet.spark.io;
-  exports org.apache.mxnet.spark.optimizer;
+  exports org.apache.mxnet.optimizer;
 }

--- a/scipy/src/main/java9/module-info.java
+++ b/scipy/src/main/java9/module-info.java
@@ -1,6 +1,4 @@
 module org.bytedeco.scipy {
   requires transitive org.bytedeco.javacpp;
-  exports org.bytedeco.scipy.global;
   exports org.bytedeco.scipy.presets;
-  exports org.bytedeco.scipy;
 }


### PR DESCRIPTION
Result of automatic validation of all non-native module-info using:
```
java -p xxx.jar --describe-module org.bytedeco.xxx
```
(using java 9+)

See [PR 880](https://github.com/bytedeco/javacpp-presets/pull/880)
