### PR TITLE
Replace compile with implementation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We can also have everything downloaded and installed automatically with:
  * Gradle (inside the `build.gradle` file)
 ```groovy
   dependencies {
-    compile group: 'org.bytedeco', name: moduleName + '-platform', version: moduleVersion + '-1.5.4'
+    implementation group: 'org.bytedeco', name: moduleName + '-platform', version: moduleVersion + '-1.5.4'
   }
 ```
 


### PR DESCRIPTION
The compile configuration is deprecated, so we need to replace it with implementation 
https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph