### PR TITLE
Implement module-independent data retrieval operations for LLVMNamedMDNodeRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add `NamedMetadataOperations.h` implementing data retrieval operations for LLVM nodes ([pull #995](https://github.com/bytedeco/javacpp-presets/pull/995))
  * Enable OpenMP for ONNX Runtime on Mac once again ([issue #917](https://github.com/bytedeco/javacpp-presets/issues/917))
  * Build OpenCV without OpenBLAS when environment variable `NOOPENBLAS=yes` ([pull #987](https://github.com/bytedeco/javacpp-presets/pull/987))
  * Enable OpenCL acceleration for DNNL ([issue #938](https://github.com/bytedeco/javacpp-presets/issues/938))

--- a/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LLVMMCJITCompilerOptions.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LLVMMCJITCompilerOptions.java
@@ -26,7 +26,7 @@ public class LLVMMCJITCompilerOptions extends Pointer {
         return (LLVMMCJITCompilerOptions)super.position(position);
     }
     @Override public LLVMMCJITCompilerOptions getPointer(long i) {
-        return new LLVMMCJITCompilerOptions(this).position(position + i);
+        return new LLVMMCJITCompilerOptions((Pointer)this).position(position + i);
     }
 
   public native @Cast("unsigned") int OptLevel(); public native LLVMMCJITCompilerOptions OptLevel(int setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LLVMOpInfo1.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LLVMOpInfo1.java
@@ -26,7 +26,7 @@ public class LLVMOpInfo1 extends Pointer {
         return (LLVMOpInfo1)super.position(position);
     }
     @Override public LLVMOpInfo1 getPointer(long i) {
-        return new LLVMOpInfo1(this).position(position + i);
+        return new LLVMOpInfo1((Pointer)this).position(position + i);
     }
 
   public native @ByRef LLVMOpInfoSymbol1 AddSymbol(); public native LLVMOpInfo1 AddSymbol(LLVMOpInfoSymbol1 setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LLVMOpInfoSymbol1.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LLVMOpInfoSymbol1.java
@@ -46,7 +46,7 @@ public class LLVMOpInfoSymbol1 extends Pointer {
         return (LLVMOpInfoSymbol1)super.position(position);
     }
     @Override public LLVMOpInfoSymbol1 getPointer(long i) {
-        return new LLVMOpInfoSymbol1(this).position(position + i);
+        return new LLVMOpInfoSymbol1((Pointer)this).position(position + i);
     }
 
   public native @Cast("uint64_t") long Present(); public native LLVMOpInfoSymbol1 Present(long setter);  /* 1 if this symbol is present */

--- a/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LTOObjectBuffer.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/LLVM/LTOObjectBuffer.java
@@ -39,7 +39,7 @@ public class LTOObjectBuffer extends Pointer {
         return (LTOObjectBuffer)super.position(position);
     }
     @Override public LTOObjectBuffer getPointer(long i) {
-        return new LTOObjectBuffer(this).position(position + i);
+        return new LTOObjectBuffer((Pointer)this).position(position + i);
     }
 
   public native @Cast("const char*") BytePointer Buffer(); public native LTOObjectBuffer Buffer(BytePointer setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCodeCompleteResults.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCodeCompleteResults.java
@@ -35,7 +35,7 @@ public class CXCodeCompleteResults extends Pointer {
         return (CXCodeCompleteResults)super.position(position);
     }
     @Override public CXCodeCompleteResults getPointer(long i) {
-        return new CXCodeCompleteResults(this).position(position + i);
+        return new CXCodeCompleteResults((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXComment.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXComment.java
@@ -41,7 +41,7 @@ public class CXComment extends Pointer {
         return (CXComment)super.position(position);
     }
     @Override public CXComment getPointer(long i) {
-        return new CXComment(this).position(position + i);
+        return new CXComment((Pointer)this).position(position + i);
     }
 
   public native @Const Pointer ASTNode(); public native CXComment ASTNode(Pointer setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCompletionResult.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCompletionResult.java
@@ -31,7 +31,7 @@ public class CXCompletionResult extends Pointer {
         return (CXCompletionResult)super.position(position);
     }
     @Override public CXCompletionResult getPointer(long i) {
-        return new CXCompletionResult(this).position(position + i);
+        return new CXCompletionResult((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCursor.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCursor.java
@@ -46,7 +46,7 @@ public class CXCursor extends Pointer {
         return (CXCursor)super.position(position);
     }
     @Override public CXCursor getPointer(long i) {
-        return new CXCursor(this).position(position + i);
+        return new CXCursor((Pointer)this).position(position + i);
     }
 
   public native @Cast("CXCursorKind") int kind(); public native CXCursor kind(int setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCursorAndRangeVisitor.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXCursorAndRangeVisitor.java
@@ -28,7 +28,7 @@ public class CXCursorAndRangeVisitor extends Pointer {
         return (CXCursorAndRangeVisitor)super.position(position);
     }
     @Override public CXCursorAndRangeVisitor getPointer(long i) {
-        return new CXCursorAndRangeVisitor(this).position(position + i);
+        return new CXCursorAndRangeVisitor((Pointer)this).position(position + i);
     }
 
   public native Pointer context(); public native CXCursorAndRangeVisitor context(Pointer setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXFileUniqueID.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXFileUniqueID.java
@@ -32,7 +32,7 @@ public class CXFileUniqueID extends Pointer {
         return (CXFileUniqueID)super.position(position);
     }
     @Override public CXFileUniqueID getPointer(long i) {
-        return new CXFileUniqueID(this).position(position + i);
+        return new CXFileUniqueID((Pointer)this).position(position + i);
     }
 
   public native @Cast("unsigned long long") long data(int i); public native CXFileUniqueID data(int i, long setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxAttrInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxAttrInfo.java
@@ -28,7 +28,7 @@ public class CXIdxAttrInfo extends Pointer {
         return (CXIdxAttrInfo)super.position(position);
     }
     @Override public CXIdxAttrInfo getPointer(long i) {
-        return new CXIdxAttrInfo(this).position(position + i);
+        return new CXIdxAttrInfo((Pointer)this).position(position + i);
     }
 
   public native @Cast("CXIdxAttrKind") int kind(); public native CXIdxAttrInfo kind(int setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxBaseClassInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxBaseClassInfo.java
@@ -28,7 +28,7 @@ public class CXIdxBaseClassInfo extends Pointer {
         return (CXIdxBaseClassInfo)super.position(position);
     }
     @Override public CXIdxBaseClassInfo getPointer(long i) {
-        return new CXIdxBaseClassInfo(this).position(position + i);
+        return new CXIdxBaseClassInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxEntityInfo base(); public native CXIdxBaseClassInfo base(CXIdxEntityInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxCXXClassDeclInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxCXXClassDeclInfo.java
@@ -28,7 +28,7 @@ public class CXIdxCXXClassDeclInfo extends Pointer {
         return (CXIdxCXXClassDeclInfo)super.position(position);
     }
     @Override public CXIdxCXXClassDeclInfo getPointer(long i) {
-        return new CXIdxCXXClassDeclInfo(this).position(position + i);
+        return new CXIdxCXXClassDeclInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxDeclInfo declInfo(); public native CXIdxCXXClassDeclInfo declInfo(CXIdxDeclInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxContainerInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxContainerInfo.java
@@ -28,7 +28,7 @@ public class CXIdxContainerInfo extends Pointer {
         return (CXIdxContainerInfo)super.position(position);
     }
     @Override public CXIdxContainerInfo getPointer(long i) {
-        return new CXIdxContainerInfo(this).position(position + i);
+        return new CXIdxContainerInfo((Pointer)this).position(position + i);
     }
 
   public native @ByRef CXCursor cursor(); public native CXIdxContainerInfo cursor(CXCursor setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxDeclInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxDeclInfo.java
@@ -28,7 +28,7 @@ public class CXIdxDeclInfo extends Pointer {
         return (CXIdxDeclInfo)super.position(position);
     }
     @Override public CXIdxDeclInfo getPointer(long i) {
-        return new CXIdxDeclInfo(this).position(position + i);
+        return new CXIdxDeclInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxEntityInfo entityInfo(); public native CXIdxDeclInfo entityInfo(CXIdxEntityInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxEntityInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxEntityInfo.java
@@ -28,7 +28,7 @@ public class CXIdxEntityInfo extends Pointer {
         return (CXIdxEntityInfo)super.position(position);
     }
     @Override public CXIdxEntityInfo getPointer(long i) {
-        return new CXIdxEntityInfo(this).position(position + i);
+        return new CXIdxEntityInfo((Pointer)this).position(position + i);
     }
 
   public native @Cast("CXIdxEntityKind") int kind(); public native CXIdxEntityInfo kind(int setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxEntityRefInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxEntityRefInfo.java
@@ -31,7 +31,7 @@ public class CXIdxEntityRefInfo extends Pointer {
         return (CXIdxEntityRefInfo)super.position(position);
     }
     @Override public CXIdxEntityRefInfo getPointer(long i) {
-        return new CXIdxEntityRefInfo(this).position(position + i);
+        return new CXIdxEntityRefInfo((Pointer)this).position(position + i);
     }
 
   public native @Cast("CXIdxEntityRefKind") int kind(); public native CXIdxEntityRefInfo kind(int setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxIBOutletCollectionAttrInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxIBOutletCollectionAttrInfo.java
@@ -28,7 +28,7 @@ public class CXIdxIBOutletCollectionAttrInfo extends Pointer {
         return (CXIdxIBOutletCollectionAttrInfo)super.position(position);
     }
     @Override public CXIdxIBOutletCollectionAttrInfo getPointer(long i) {
-        return new CXIdxIBOutletCollectionAttrInfo(this).position(position + i);
+        return new CXIdxIBOutletCollectionAttrInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxAttrInfo attrInfo(); public native CXIdxIBOutletCollectionAttrInfo attrInfo(CXIdxAttrInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxImportedASTFileInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxImportedASTFileInfo.java
@@ -31,7 +31,7 @@ public class CXIdxImportedASTFileInfo extends Pointer {
         return (CXIdxImportedASTFileInfo)super.position(position);
     }
     @Override public CXIdxImportedASTFileInfo getPointer(long i) {
-        return new CXIdxImportedASTFileInfo(this).position(position + i);
+        return new CXIdxImportedASTFileInfo((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxIncludedFileInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxIncludedFileInfo.java
@@ -31,7 +31,7 @@ public class CXIdxIncludedFileInfo extends Pointer {
         return (CXIdxIncludedFileInfo)super.position(position);
     }
     @Override public CXIdxIncludedFileInfo getPointer(long i) {
-        return new CXIdxIncludedFileInfo(this).position(position + i);
+        return new CXIdxIncludedFileInfo((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxLoc.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxLoc.java
@@ -31,7 +31,7 @@ public class CXIdxLoc extends Pointer {
         return (CXIdxLoc)super.position(position);
     }
     @Override public CXIdxLoc getPointer(long i) {
-        return new CXIdxLoc(this).position(position + i);
+        return new CXIdxLoc((Pointer)this).position(position + i);
     }
 
   public native Pointer ptr_data(int i); public native CXIdxLoc ptr_data(int i, Pointer setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCCategoryDeclInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCCategoryDeclInfo.java
@@ -28,7 +28,7 @@ public class CXIdxObjCCategoryDeclInfo extends Pointer {
         return (CXIdxObjCCategoryDeclInfo)super.position(position);
     }
     @Override public CXIdxObjCCategoryDeclInfo getPointer(long i) {
-        return new CXIdxObjCCategoryDeclInfo(this).position(position + i);
+        return new CXIdxObjCCategoryDeclInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxObjCContainerDeclInfo containerInfo(); public native CXIdxObjCCategoryDeclInfo containerInfo(CXIdxObjCContainerDeclInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCContainerDeclInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCContainerDeclInfo.java
@@ -28,7 +28,7 @@ public class CXIdxObjCContainerDeclInfo extends Pointer {
         return (CXIdxObjCContainerDeclInfo)super.position(position);
     }
     @Override public CXIdxObjCContainerDeclInfo getPointer(long i) {
-        return new CXIdxObjCContainerDeclInfo(this).position(position + i);
+        return new CXIdxObjCContainerDeclInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxDeclInfo declInfo(); public native CXIdxObjCContainerDeclInfo declInfo(CXIdxDeclInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCInterfaceDeclInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCInterfaceDeclInfo.java
@@ -28,7 +28,7 @@ public class CXIdxObjCInterfaceDeclInfo extends Pointer {
         return (CXIdxObjCInterfaceDeclInfo)super.position(position);
     }
     @Override public CXIdxObjCInterfaceDeclInfo getPointer(long i) {
-        return new CXIdxObjCInterfaceDeclInfo(this).position(position + i);
+        return new CXIdxObjCInterfaceDeclInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxObjCContainerDeclInfo containerInfo(); public native CXIdxObjCInterfaceDeclInfo containerInfo(CXIdxObjCContainerDeclInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCPropertyDeclInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCPropertyDeclInfo.java
@@ -28,7 +28,7 @@ public class CXIdxObjCPropertyDeclInfo extends Pointer {
         return (CXIdxObjCPropertyDeclInfo)super.position(position);
     }
     @Override public CXIdxObjCPropertyDeclInfo getPointer(long i) {
-        return new CXIdxObjCPropertyDeclInfo(this).position(position + i);
+        return new CXIdxObjCPropertyDeclInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxDeclInfo declInfo(); public native CXIdxObjCPropertyDeclInfo declInfo(CXIdxDeclInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCProtocolRefInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCProtocolRefInfo.java
@@ -28,7 +28,7 @@ public class CXIdxObjCProtocolRefInfo extends Pointer {
         return (CXIdxObjCProtocolRefInfo)super.position(position);
     }
     @Override public CXIdxObjCProtocolRefInfo getPointer(long i) {
-        return new CXIdxObjCProtocolRefInfo(this).position(position + i);
+        return new CXIdxObjCProtocolRefInfo((Pointer)this).position(position + i);
     }
 
   public native @Const CXIdxEntityInfo protocol(); public native CXIdxObjCProtocolRefInfo protocol(CXIdxEntityInfo setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCProtocolRefListInfo.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXIdxObjCProtocolRefListInfo.java
@@ -28,7 +28,7 @@ public class CXIdxObjCProtocolRefListInfo extends Pointer {
         return (CXIdxObjCProtocolRefListInfo)super.position(position);
     }
     @Override public CXIdxObjCProtocolRefListInfo getPointer(long i) {
-        return new CXIdxObjCProtocolRefListInfo(this).position(position + i);
+        return new CXIdxObjCProtocolRefListInfo((Pointer)this).position(position + i);
     }
 
   @MemberGetter public native @Const CXIdxObjCProtocolRefInfo protocols(int i);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXPlatformAvailability.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXPlatformAvailability.java
@@ -32,7 +32,7 @@ public class CXPlatformAvailability extends Pointer {
         return (CXPlatformAvailability)super.position(position);
     }
     @Override public CXPlatformAvailability getPointer(long i) {
-        return new CXPlatformAvailability(this).position(position + i);
+        return new CXPlatformAvailability((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXSourceLocation.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXSourceLocation.java
@@ -52,7 +52,7 @@ public class CXSourceLocation extends Pointer {
         return (CXSourceLocation)super.position(position);
     }
     @Override public CXSourceLocation getPointer(long i) {
-        return new CXSourceLocation(this).position(position + i);
+        return new CXSourceLocation((Pointer)this).position(position + i);
     }
 
   public native @Const Pointer ptr_data(int i); public native CXSourceLocation ptr_data(int i, Pointer setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXSourceRange.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXSourceRange.java
@@ -34,7 +34,7 @@ public class CXSourceRange extends Pointer {
         return (CXSourceRange)super.position(position);
     }
     @Override public CXSourceRange getPointer(long i) {
-        return new CXSourceRange(this).position(position + i);
+        return new CXSourceRange((Pointer)this).position(position + i);
     }
 
   public native @Const Pointer ptr_data(int i); public native CXSourceRange ptr_data(int i, Pointer setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXSourceRangeList.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXSourceRangeList.java
@@ -31,7 +31,7 @@ public class CXSourceRangeList extends Pointer {
         return (CXSourceRangeList)super.position(position);
     }
     @Override public CXSourceRangeList getPointer(long i) {
-        return new CXSourceRangeList(this).position(position + i);
+        return new CXSourceRangeList((Pointer)this).position(position + i);
     }
 
   /** The number of ranges in the \c ranges array. */

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXString.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXString.java
@@ -43,7 +43,7 @@ public class CXString extends Pointer {
         return (CXString)super.position(position);
     }
     @Override public CXString getPointer(long i) {
-        return new CXString(this).position(position + i);
+        return new CXString((Pointer)this).position(position + i);
     }
 
   public String getString() {

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXStringSet.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXStringSet.java
@@ -28,7 +28,7 @@ public class CXStringSet extends Pointer {
         return (CXStringSet)super.position(position);
     }
     @Override public CXStringSet getPointer(long i) {
-        return new CXStringSet(this).position(position + i);
+        return new CXStringSet((Pointer)this).position(position + i);
     }
 
   public native CXString Strings(); public native CXStringSet Strings(CXString setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXTUResourceUsage.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXTUResourceUsage.java
@@ -31,7 +31,7 @@ public class CXTUResourceUsage extends Pointer {
         return (CXTUResourceUsage)super.position(position);
     }
     @Override public CXTUResourceUsage getPointer(long i) {
-        return new CXTUResourceUsage(this).position(position + i);
+        return new CXTUResourceUsage((Pointer)this).position(position + i);
     }
 
   /* Private data member, used for queries. */

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXTUResourceUsageEntry.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXTUResourceUsageEntry.java
@@ -28,7 +28,7 @@ public class CXTUResourceUsageEntry extends Pointer {
         return (CXTUResourceUsageEntry)super.position(position);
     }
     @Override public CXTUResourceUsageEntry getPointer(long i) {
-        return new CXTUResourceUsageEntry(this).position(position + i);
+        return new CXTUResourceUsageEntry((Pointer)this).position(position + i);
     }
 
   /* The memory usage category. */

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXToken.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXToken.java
@@ -31,7 +31,7 @@ public class CXToken extends Pointer {
         return (CXToken)super.position(position);
     }
     @Override public CXToken getPointer(long i) {
-        return new CXToken(this).position(position + i);
+        return new CXToken((Pointer)this).position(position + i);
     }
 
   public native @Cast("unsigned") int int_data(int i); public native CXToken int_data(int i, int setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXType.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXType.java
@@ -32,7 +32,7 @@ public class CXType extends Pointer {
         return (CXType)super.position(position);
     }
     @Override public CXType getPointer(long i) {
-        return new CXType(this).position(position + i);
+        return new CXType((Pointer)this).position(position + i);
     }
 
   public native @Cast("CXTypeKind") int kind(); public native CXType kind(int setter);

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXUnsavedFile.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXUnsavedFile.java
@@ -35,7 +35,7 @@ public class CXUnsavedFile extends Pointer {
         return (CXUnsavedFile)super.position(position);
     }
     @Override public CXUnsavedFile getPointer(long i) {
-        return new CXUnsavedFile(this).position(position + i);
+        return new CXUnsavedFile((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/CXVersion.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/CXVersion.java
@@ -31,7 +31,7 @@ public class CXVersion extends Pointer {
         return (CXVersion)super.position(position);
     }
     @Override public CXVersion getPointer(long i) {
-        return new CXVersion(this).position(position + i);
+        return new CXVersion((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/clang/IndexerCallbacks.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/clang/IndexerCallbacks.java
@@ -32,7 +32,7 @@ public class IndexerCallbacks extends Pointer {
         return (IndexerCallbacks)super.position(position);
     }
     @Override public IndexerCallbacks getPointer(long i) {
-        return new IndexerCallbacks(this).position(position + i);
+        return new IndexerCallbacks((Pointer)this).position(position + i);
     }
 
   /**

--- a/llvm/src/gen/java/org/bytedeco/llvm/global/LLVM.java
+++ b/llvm/src/gen/java/org/bytedeco/llvm/global/LLVM.java
@@ -10679,6 +10679,87 @@ public static native void createOptimizedJITCompilerForModule(
 // #endif
 
 
+// Parsed from <NamedMetadataOperations.h>
+
+/*
+ * Copyright (C) 2021 Mats Larsen
+ *
+ * Licensed either under the Apache License, Version 2.0, or (at your option)
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (subject to the "Classpath" exception),
+ * either version 2, or any later version (collectively, the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.gnu.org/licenses/
+ *     http://www.gnu.org/software/classpath/license.html
+ *
+ * or as provided in the LICENSE.txt file that accompanied this code.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// #ifndef NAMED_METADATA_OPERATIONS_H
+// #define NAMED_METADATA_OPERATIONS_H
+
+// #include "llvm/IR/LLVMContext.h"
+// #include "llvm/IR/Metadata.h"
+// #include "llvm-c/Core.h"
+// #include "llvm-c/Types.h"
+
+/**
+ * Exact re-implementation of LLVMGetNamedMetadataNumOperands without providing
+ * a LLVMModuleRef parameter
+ *
+ * Pass a LLVMNamedMDNodeRef instead, which is the true owner for the data
+ * anyways
+ *
+ * See /llvm/lib/IR/Core.cpp for original implementation
+ */
+@Namespace("llvm") public static native @Cast("unsigned") int getNamedMDNodeNumOperands(LLVMNamedMDNodeRef NodeRef);
+
+/**
+ * Exact re-implementation of LLVMGetNamedMetadataOperands without providing
+ * a LLVMModuleRef parameter.
+ *
+ * This requires a LLVMContextRef instance because conversion from Metadata to
+ * Value requires a context in which the new Value will reside in.
+ *
+ * See /llvm/lib/IR/Core.cpp for original implementation
+ */
+@Namespace("llvm") public static native void getNamedMDNodeOperands(
+    LLVMNamedMDNodeRef NodeRef,
+    @ByPtrPtr LLVMValueRef Dest,
+    LLVMContextRef InContext
+);
+@Namespace("llvm") public static native void getNamedMDNodeOperands(
+    LLVMNamedMDNodeRef NodeRef,
+    @Cast("LLVMValueRef*") PointerPointer Dest,
+    LLVMContextRef InContext
+);
+
+/**
+ * Inlined re-implementation of LLVMAddNamedMetadataOperand without providing
+ * a LLVMModuleRef parameter.
+ *
+ * This implementation inlines the statically defined "extractMDNode" in
+ * Core.cpp which the original implementation uses.
+ *
+ * See /llvm/lib/IR/Core.cpp for original implementation
+ */
+@Namespace("llvm") public static native void addNamedMDNodeOperand(
+    LLVMNamedMDNodeRef NodeRef,
+    LLVMValueRef Val
+);
+
+ // namespace llvm
+
+// #endif // NAMED_METADATA_OPERATIONS_H
+
 // Parsed from <TargetStubs.h>
 
 /*

--- a/llvm/src/main/java/org/bytedeco/llvm/presets/LLVM.java
+++ b/llvm/src/main/java/org/bytedeco/llvm/presets/LLVM.java
@@ -35,7 +35,7 @@ import org.bytedeco.javacpp.tools.*;
                "<llvm-c/Comdat.h>", "<llvm-c/DebugInfo.h>", "<llvm-c/Error.h>", "<llvm-c/ErrorHandling.h>", "<llvm-c/OrcBindings.h>", "<llvm-c/Remarks.h>",
                "<llvm-c/Transforms/AggressiveInstCombine.h>", "<llvm-c/Transforms/Coroutines.h>", "<llvm-c/Transforms/InstCombine.h>",
                "<llvm-c/Transforms/IPO.h>", "<llvm-c/Transforms/PassManagerBuilder.h>", "<llvm-c/Transforms/Scalar.h>", "<llvm-c/Transforms/Utils.h>", "<llvm-c/Transforms/Vectorize.h>",
-               "<polly/LinkAllPasses.h>", "<FullOptimization.h>", "<TargetStubs.h>"},
+               "<polly/LinkAllPasses.h>", "<FullOptimization.h>", "<TargetStubs.h>", "<NamedMetadataOperations.h>"},
     compiler = "cpp14", link = {"LLVM-11", "LTO@.11", "Remarks@.11"}, resource = {"include", "lib"}),
         @Platform(value = "macosx", link = {"LLVM", "LTO", "Remarks"}),
         @Platform(value = "windows", link = {"LLVM", "LTO", "Remarks"})})

--- a/llvm/src/main/java/org/bytedeco/llvm/presets/LLVM.java
+++ b/llvm/src/main/java/org/bytedeco/llvm/presets/LLVM.java
@@ -35,7 +35,7 @@ import org.bytedeco.javacpp.tools.*;
                "<llvm-c/Comdat.h>", "<llvm-c/DebugInfo.h>", "<llvm-c/Error.h>", "<llvm-c/ErrorHandling.h>", "<llvm-c/OrcBindings.h>", "<llvm-c/Remarks.h>",
                "<llvm-c/Transforms/AggressiveInstCombine.h>", "<llvm-c/Transforms/Coroutines.h>", "<llvm-c/Transforms/InstCombine.h>",
                "<llvm-c/Transforms/IPO.h>", "<llvm-c/Transforms/PassManagerBuilder.h>", "<llvm-c/Transforms/Scalar.h>", "<llvm-c/Transforms/Utils.h>", "<llvm-c/Transforms/Vectorize.h>",
-               "<polly/LinkAllPasses.h>", "<FullOptimization.h>", "<TargetStubs.h>", "<NamedMetadataOperations.h>"},
+               "<polly/LinkAllPasses.h>", "<FullOptimization.h>", "<NamedMetadataOperations.h>", "<TargetStubs.h>"},
     compiler = "cpp14", link = {"LLVM-11", "LTO@.11", "Remarks@.11"}, resource = {"include", "lib"}),
         @Platform(value = "macosx", link = {"LLVM", "LTO", "Remarks"}),
         @Platform(value = "windows", link = {"LLVM", "LTO", "Remarks"})})

--- a/llvm/src/main/resources/org/bytedeco/llvm/include/NamedMetadataOperations.h
+++ b/llvm/src/main/resources/org/bytedeco/llvm/include/NamedMetadataOperations.h
@@ -55,7 +55,6 @@ extern "C" unsigned NamedMDNodeGetOperandCount(LLVMNamedMDNodeRef NodeRef) {
  */
 extern "C" void NamedMDNodeGetOperands(
     LLVMNamedMDNodeRef NodeRef,
-    const char* Name,
     LLVMValueRef *Dest,
     LLVMContextRef InContext
 ) {
@@ -77,7 +76,6 @@ extern "C" void NamedMDNodeGetOperands(
  */
 extern "C" void NamedMDNodeAddOperand(
     LLVMNamedMDNodeRef NodeRef,
-    const char* Name,
     LLVMValueRef Val
 ) {
     assert(Val && "Expected not-null value Val");

--- a/llvm/src/main/resources/org/bytedeco/llvm/include/NamedMetadataOperations.h
+++ b/llvm/src/main/resources/org/bytedeco/llvm/include/NamedMetadataOperations.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2021 Mats Larsen
+ *
+ * Licensed either under the Apache License, Version 2.0, or (at your option)
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (subject to the "Classpath" exception),
+ * either version 2, or any later version (collectively, the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.gnu.org/licenses/
+ *     http://www.gnu.org/software/classpath/license.html
+ *
+ * or as provided in the LICENSE.txt file that accompanied this code.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NAMED_METADATA_OPERATIONS_H
+#define NAMED_METADATA_OPERATIONS_H
+
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm-c/Core.h"
+#include "llvm-c/Types.h"
+
+namespace llvm {
+
+/**
+ * Exact re-implementation of LLVMGetNamedMetadataNumOperands without providing
+ * a LLVMModuleRef parameter
+ *
+ * Pass a LLVMNamedMDNodeRef instead, which is the true owner for the data
+ * anyways
+ *
+ * See /llvm/lib/IR/Core.cpp for original implementation
+ */
+extern "C" unsigned NamedMDNodeGetOperandCount(LLVMNamedMDNodeRef NodeRef) {
+    NamedMDNode *N = unwrap(NodeRef);
+    return N->getNumOperands();
+}
+
+/**
+ * Exact re-implementation of LLVMGetNamedMetadataOperands without providing
+ * a LLVMModuleRef parameter.
+ *
+ * This requires a LLVMContextRef instance because conversion from Metadata to
+ * Value requires a context in which the new Value will reside in.
+ *
+ * See /llvm/lib/IR/Core.cpp for original implementation
+ */
+extern "C" void NamedMDNodeGetOperands(
+    LLVMNamedMDNodeRef NodeRef,
+    const char* Name,
+    LLVMValueRef *Dest,
+    LLVMContextRef InContext
+) {
+    NamedMDNode *N = unwrap(NodeRef);
+    LLVMContext *C = unwrap(InContext);
+    for (unsigned i = 0; i < N->getNumOperands(); i++) {
+        Dest[i] = wrap(MetadataAsValue::get(*C, N->getOperand(i)));
+    }
+}
+
+/**
+ * Inlined re-implementation of LLVMAddNamedMetadataOperand without providing
+ * a LLVMModuleRef parameter.
+ *
+ * This implementation inlines the statically defined "extractMDNode" in
+ * Core.cpp which the original implementation uses.
+ *
+ * See /llvm/lib/IR/Core.cpp for original implementation
+ */
+extern "C" void NamedMDNodeAddOperand(
+    LLVMNamedMDNodeRef NodeRef,
+    const char* Name,
+    LLVMValueRef Val
+) {
+    assert(Val && "Expected not-null value Val");
+
+    NamedMDNode *N = unwrap(NodeRef);
+    MetadataAsValue *MAV = unwrap<MetadataAsValue>(Val);
+    Metadata *MD = MAV->getMetadata();
+    MDNode* Metadata;
+    assert((isa<MDNode>(MD) || isa<ConstantAsMetadata>(MD)) && "Expected a metadata node or a canonicalized constant");
+
+    if (MDNode* NN = dyn_cast<MDNode>(MD)) {
+        Metadata = NN;
+    }
+    Metadata = MDNode::get(MAV->getContext(), MD);
+
+    N->addOperand(Metadata);
+}
+
+} // namespace llvm
+
+#endif // NAMED_METADATA_OPERATIONS_H

--- a/llvm/src/main/resources/org/bytedeco/llvm/include/NamedMetadataOperations.h
+++ b/llvm/src/main/resources/org/bytedeco/llvm/include/NamedMetadataOperations.h
@@ -39,7 +39,7 @@ namespace llvm {
  *
  * See /llvm/lib/IR/Core.cpp for original implementation
  */
-extern "C" unsigned NamedMDNodeGetOperandCount(LLVMNamedMDNodeRef NodeRef) {
+extern "C" unsigned getNamedMDNodeNumOperands(LLVMNamedMDNodeRef NodeRef) {
     NamedMDNode *N = unwrap(NodeRef);
     return N->getNumOperands();
 }
@@ -53,7 +53,7 @@ extern "C" unsigned NamedMDNodeGetOperandCount(LLVMNamedMDNodeRef NodeRef) {
  *
  * See /llvm/lib/IR/Core.cpp for original implementation
  */
-extern "C" void NamedMDNodeGetOperands(
+extern "C" void getNamedMDNodeOperands(
     LLVMNamedMDNodeRef NodeRef,
     LLVMValueRef *Dest,
     LLVMContextRef InContext
@@ -74,7 +74,7 @@ extern "C" void NamedMDNodeGetOperands(
  *
  * See /llvm/lib/IR/Core.cpp for original implementation
  */
-extern "C" void NamedMDNodeAddOperand(
+extern "C" void addNamedMDNodeOperand(
     LLVMNamedMDNodeRef NodeRef,
     LLVMValueRef Val
 ) {


### PR DESCRIPTION
I'd like to expand the LLVM C API, more specifically the Modules/NamedMDNode API as it has a rather interesting way to retrieve data owned by a `LLVMNamedMDNodeRef`

In the C++ API, all the data associated with a `llvm::NamedMDNode` is owned by the node itself so it would only make sense to pull said data from the node itself. For unknown? reasons [1], the C API requires the owning module of a `LLVMNamedMDNodeRef` to retrieve the data. Looking closer at the implementation we can tell that we shouldn't need the module to retrieve parts of this data.

The functions I have added in this patch have the same functionality as the ones present in the C API. The only difference is that we don't need to provide a module to look up a LLVMNamedMDNodeRef inside of, instead we provide the instance returned by `LLVMGetNamedMetadata` or `LLVMGetOrInsertNamedMetadata`.

###### [1]: I imagine it was designed this way because in the C++ API, `llvm::NamedMDNode`s may be detached and not associated with a Module so providing the owning module was the natural choice, but this is not possible to do through the C API alone which means we can do better.