### PR TITLE
Remove JPMS dependencies from native modules

### DIFF
--- a/arpack-ng/pom.xml
+++ b/arpack-ng/pom.xml
@@ -16,9 +16,6 @@
 
   <properties>
     <javacpp.packageName>arpackng</javacpp.packageName>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
   </properties>
 
   <dependencies>

--- a/caffe/pom.xml
+++ b/caffe/pom.xml
@@ -14,14 +14,6 @@
   <version>1.0-${project.parent.version}</version>
   <name>JavaCPP Presets for Caffe</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.opencv.${javacpp.platform.module};
-      requires org.bytedeco.hdf5.${javacpp.platform.module};
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/chilitags/pom.xml
+++ b/chilitags/pom.xml
@@ -14,12 +14,6 @@
   <version>master-${project.parent.version}</version>
   <name>JavaCPP Presets for Chilitags</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.opencv.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/cminpack/pom.xml
+++ b/cminpack/pom.xml
@@ -14,12 +14,6 @@
   <version>1.3.8-${project.parent.version}</version>
   <name>JavaCPP Presets for CMINPACK</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/dnnl/pom.xml
+++ b/dnnl/pom.xml
@@ -14,12 +14,6 @@
   <version>2.2.1-${project.parent.version}</version>
   <name>JavaCPP Presets for DNNL</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.opencl.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/flandmark/pom.xml
+++ b/flandmark/pom.xml
@@ -14,12 +14,6 @@
   <version>1.07-${project.parent.version}</version>
   <name>JavaCPP Presets for flandmark</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.opencv.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/gsl/pom.xml
+++ b/gsl/pom.xml
@@ -14,12 +14,6 @@
   <version>2.6-${project.parent.version}</version>
   <name>JavaCPP Presets for GSL</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/gym/pom.xml
+++ b/gym/pom.xml
@@ -14,13 +14,6 @@
   <version>0.18.1-${project.parent.version}</version>
   <name>JavaCPP Presets for Gym</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.opencv.${javacpp.platform.module};
-      requires org.bytedeco.scipy.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/mxnet/pom.xml
+++ b/mxnet/pom.xml
@@ -14,13 +14,6 @@
   <version>1.8.0-${project.parent.version}</version>
   <name>JavaCPP Presets for MXNet</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.opencv.${javacpp.platform.module};
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/ngraph/pom.xml
+++ b/ngraph/pom.xml
@@ -14,12 +14,6 @@
   <version>0.26.0-${project.parent.version}</version>
   <name>JavaCPP Presets for nGraph</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.mkldnn.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/numpy/pom.xml
+++ b/numpy/pom.xml
@@ -14,13 +14,6 @@
   <version>1.20.2-${project.parent.version}</version>
   <name>JavaCPP Presets for NumPy</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-      requires org.bytedeco.cpython.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/nvcodec/pom.xml
+++ b/nvcodec/pom.xml
@@ -14,12 +14,6 @@
   <version>11.0.10-${project.parent.version}</version>
   <name>JavaCPP Presets for NVIDIA Video Codec SDK</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.cuda.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/onnxruntime/pom.xml
+++ b/onnxruntime/pom.xml
@@ -16,9 +16,6 @@
 
   <properties>
     <onnxruntime.path>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/onnxruntime</onnxruntime.path>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.dnnl.${javacpp.platform.module};
-    </javacpp.nativeRequires>
   </properties>
 
   <dependencies>

--- a/opencv/pom.xml
+++ b/opencv/pom.xml
@@ -14,12 +14,6 @@
   <version>4.5.2-${project.parent.version}</version>
   <name>JavaCPP Presets for OpenCV</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/openpose/pom.xml
+++ b/openpose/pom.xml
@@ -14,15 +14,6 @@
   <version>1.7.0-${project.parent.version}</version>
   <name>JavaCPP Presets for OpenPose</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.caffe.${javacpp.platform.module};
-      requires org.bytedeco.opencv.${javacpp.platform.module};
-      requires org.bytedeco.hdf5.${javacpp.platform.module};
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -395,9 +395,6 @@
                   <file>${project.build.directory}/${project.artifactId}-${javacpp.platform}${javacpp.platform.extension}.jar</file>
                   <moduleInfoSource>
                     open module org.bytedeco.${javacpp.packageName}.${javacpp.platform.module} {
-                      requires transitive org.bytedeco.${javacpp.packageName};
-                      requires org.bytedeco.javacpp.${javacpp.platform.module};
-                      ${javacpp.nativeRequires}
                     }
                   </moduleInfoSource>
                 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <javacpp.parser.skip>false</javacpp.parser.skip>     <!-- To skip header file parsing phase: -Djavacpp.parser.skip=true  -->
     <javacpp.compiler.skip>false</javacpp.compiler.skip> <!-- To skip native compilation phase: -Djavacpp.compiler.skip=true -->
     <javacpp.moduleId>${project.artifactId}</javacpp.moduleId>
-    <javacpp.nativeRequires/>
     <javacpp.packageName>${project.artifactId}</javacpp.packageName>
     <javacpp.platform.nativeOutputPath>org/bytedeco/${javacpp.packageName}/${javacpp.platform}${javacpp.platform.extension}</javacpp.platform.nativeOutputPath>
     <javacpp.platform.root></javacpp.platform.root>
@@ -395,6 +394,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${javacpp.platform}${javacpp.platform.extension}.jar</file>
                   <moduleInfoSource>
                     open module org.bytedeco.${javacpp.packageName}.${javacpp.platform.module} {
+                      requires transitive org.bytedeco.${javacpp.packageName};
                     }
                   </moduleInfoSource>
                 </module>

--- a/pytorch/pom.xml
+++ b/pytorch/pom.xml
@@ -14,12 +14,6 @@
   <version>1.8.1-${project.parent.version}</version>
   <name>JavaCPP Presets for PyTorch</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.openblas.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/scipy/pom.xml
+++ b/scipy/pom.xml
@@ -14,12 +14,6 @@
   <version>1.6.2-${project.parent.version}</version>
   <name>JavaCPP Presets for SciPy</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.numpy.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/tensorflow/pom.xml
+++ b/tensorflow/pom.xml
@@ -17,10 +17,6 @@
   <properties>
     <tensorflow.version>1.15.5</tensorflow.version>
     <tensorflow.path>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/tensorflow-${tensorflow.version}/</tensorflow.path>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.mkldnn.${javacpp.platform.module};
-      requires org.bytedeco.numpy.${javacpp.platform.module};
-    </javacpp.nativeRequires>
   </properties>
 
   <dependencies>

--- a/tensorrt/pom.xml
+++ b/tensorrt/pom.xml
@@ -14,12 +14,6 @@
   <version>7.2-${project.parent.version}</version>
   <name>JavaCPP Presets for TensorRT</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.cuda.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/tesseract/pom.xml
+++ b/tesseract/pom.xml
@@ -14,12 +14,6 @@
   <version>4.1.1-${project.parent.version}</version>
   <name>JavaCPP Presets for Tesseract</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.leptonica.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/tvm/pom.xml
+++ b/tvm/pom.xml
@@ -14,15 +14,6 @@
   <version>0.7.0-${project.parent.version}</version>
   <name>JavaCPP Presets for TVM</name>
 
-  <properties>
-    <javacpp.nativeRequires>
-      requires org.bytedeco.dnnl.${javacpp.platform.module};
-      requires org.bytedeco.llvm.${javacpp.platform.module};
-      requires org.bytedeco.mkl.${javacpp.platform.module};
-      requires org.bytedeco.scipy.${javacpp.platform.module};
-    </javacpp.nativeRequires>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.bytedeco</groupId>


### PR DESCRIPTION
Native module currently depends on other native modules with same system, architecture and extension.
For instance `org.bytedeco.opencv.linux.x86_64` descriptor contains `requires org.bytedeco.openblas.linux.x86_64`. But when using a specific extension, like `gpu`, module graph initialization fails when the extension doesn't exist for some dependency, like `openblas` or `javacpp` itself.

This PR removes these dependencies between modules. The preferred way to bring the native modules into the module graph is to rely on Maven dependencies using the `javacpp.platform` and `javacpp.platform.extension` properties, and on `--add-modules ALL-MODULE-PATH` option.

