### PR TITLE
Synchronize and prevent repeated package caching in all presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Synchronize `cachePackage()` and prevent repeated package caching in all presets ([pull #1071](https://github.com/bytedeco/javacpp-presets/pull/1071))
  * Build FFmpeg with VA-API enabled and bundle its libraries to avoid loading issues ([issue bytedeco/javacv#1188](https://github.com/bytedeco/javacv/issues/1188))
  * Upgrade presets for Arrow 5.0.0, DNNL 2.3.2, SciPy 1.7.1, TensorFlow Lite 2.6.0, DepthAI 2.9.0, ONNX 1.10.1, ONNX Runtime 1.8.2, and their dependencies
 

--- a/cpython/src/main/java/org/bytedeco/cpython/presets/python.java
+++ b/cpython/src/main/java/org/bytedeco/cpython/presets/python.java
@@ -208,10 +208,10 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 public class python implements InfoMapper {
     static { Loader.checkVersion("org.bytedeco", "cpython"); }
 
-    private static volatile File packageFile = null;
+    private static File packageFile = null;
 
     /** Returns {@code Loader.cacheResource("/org/bytedeco/cpython/" + Loader.getPlatform())} and monkey patches files accordingly. */
-    public static File cachePackage() throws IOException {
+    public static synchronized File cachePackage() throws IOException {
         if (packageFile != null) {
             return packageFile;
         }
@@ -251,7 +251,8 @@ public class python implements InfoMapper {
                 }
             }
         }
-        return packageFile = pythonFile;
+        packageFile = pythonFile;
+        return pythonFile;
     }
 
     /** Returns {@code {f, new File(f, "site-packages"), new File(f, "python3.9"), new File(f, "python3.9/lib-dynload"), new File(f, "python3.9/site-packages")}} where {@code File f = new File(cachePackage(), "lib")}. */

--- a/cpython/src/main/java/org/bytedeco/cpython/presets/python.java
+++ b/cpython/src/main/java/org/bytedeco/cpython/presets/python.java
@@ -208,8 +208,13 @@ import org.bytedeco.javacpp.tools.InfoMapper;
 public class python implements InfoMapper {
     static { Loader.checkVersion("org.bytedeco", "cpython"); }
 
+    private static volatile File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/cpython/" + Loader.getPlatform())} and monkey patches files accordingly. */
     public static File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
         File pythonFile = Loader.cacheResource("/org/bytedeco/cpython/" + Loader.getPlatform());
         File configDir = new File(pythonFile, "lib/python3.9/");
         if (configDir.exists()) {
@@ -246,7 +251,7 @@ public class python implements InfoMapper {
                 }
             }
         }
-        return pythonFile;
+        return packageFile = pythonFile;
     }
 
     /** Returns {@code {f, new File(f, "site-packages"), new File(f, "python3.9"), new File(f, "python3.9/lib-dynload"), new File(f, "python3.9/site-packages")}} where {@code File f = new File(cachePackage(), "lib")}. */

--- a/gym/src/main/java/org/bytedeco/gym/presets/gym.java
+++ b/gym/src/main/java/org/bytedeco/gym/presets/gym.java
@@ -52,9 +52,16 @@ import org.bytedeco.scipy.presets.*;
 public class gym {
     static { Loader.checkVersion("org.bytedeco", "gym"); }
 
+    private static File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/gym/python/")}. */
-    public static File cachePackage() throws IOException {
-        return Loader.cacheResource("/org/bytedeco/gym/python/");
+    public static synchronized File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
+        packageFile = Loader.cacheResource("/org/bytedeco/gym/python/");
+        return packageFile;
+
     }
 
     /** Returns {@code {opencv_python3.cachePackages(), scipy.cachePackages(), gym.cachePackage()}}. */

--- a/gym/src/main/java/org/bytedeco/gym/presets/gym.java
+++ b/gym/src/main/java/org/bytedeco/gym/presets/gym.java
@@ -61,7 +61,6 @@ public class gym {
         }
         packageFile = Loader.cacheResource("/org/bytedeco/gym/python/");
         return packageFile;
-
     }
 
     /** Returns {@code {opencv_python3.cachePackages(), scipy.cachePackages(), gym.cachePackage()}}. */

--- a/llvm/src/main/java/org/bytedeco/llvm/presets/LLVM.java
+++ b/llvm/src/main/java/org/bytedeco/llvm/presets/LLVM.java
@@ -45,9 +45,15 @@ import org.bytedeco.javacpp.tools.*;
 public class LLVM implements InfoMapper {
     static { Loader.checkVersion("org.bytedeco", "llvm"); }
 
+    private static File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/llvm/" + Loader.getPlatform())}. */
-    public static File cachePackage() throws IOException {
-        return Loader.cacheResource("/org/bytedeco/llvm/" + Loader.getPlatform());
+    public static synchronized File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
+        packageFile = Loader.cacheResource("/org/bytedeco/llvm/" + Loader.getPlatform());
+        return packageFile;
     }
 
     public void map(InfoMap infoMap) {

--- a/numpy/src/main/java/org/bytedeco/numpy/presets/numpy.java
+++ b/numpy/src/main/java/org/bytedeco/numpy/presets/numpy.java
@@ -83,9 +83,15 @@ import org.bytedeco.openblas.presets.*;
 public class numpy implements InfoMapper {
     static { Loader.checkVersion("org.bytedeco", "numpy"); }
 
+    private static File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/numpy/" + Loader.getPlatform() + "/python/")}. */
-    public static File cachePackage() throws IOException {
-        return Loader.cacheResource("/org/bytedeco/numpy/" + Loader.getPlatform() + "/python/");
+    public static synchronized File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
+        packageFile = Loader.cacheResource("/org/bytedeco/numpy/" + Loader.getPlatform() + "/python/");
+        return packageFile;
     }
 
     /** Returns {@code {python.cachePackages(), numpy.cachePackage()}}. */

--- a/opencv/src/main/java/org/bytedeco/opencv/opencv_python3.java
+++ b/opencv/src/main/java/org/bytedeco/opencv/opencv_python3.java
@@ -76,17 +76,22 @@ import org.bytedeco.opencv.presets.*;
 public class opencv_python3 {
     static { Loader.load(); }
 
+    private static File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/opencv/" + Loader.getPlatform() + extension + "/python/")}. */
-    public static File cachePackage() throws IOException {
+    public static synchronized File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
         Loader.load(org.bytedeco.cpython.global.python.class);
         String path = Loader.load(opencv_core.class);
         if (path != null) {
             path = path.replace(File.separatorChar, '/');
             int i = path.indexOf("/org/bytedeco/opencv/" + Loader.getPlatform());
             int j = path.lastIndexOf("/");
-            return Loader.cacheResource(path.substring(i, j) + "/python/");
+            packageFile = Loader.cacheResource(path.substring(i, j) + "/python/");
         }
-        return null;
+        return packageFile;
     }
 
     /** Returns {@code {numpy.cachePackages(), opencv.cachePackage()}}. */

--- a/scipy/src/main/java/org/bytedeco/scipy/presets/scipy.java
+++ b/scipy/src/main/java/org/bytedeco/scipy/presets/scipy.java
@@ -53,10 +53,16 @@ import org.bytedeco.numpy.presets.*;
 public class scipy {
     static { Loader.checkVersion("org.bytedeco", "scipy"); }
 
+    private static File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/scipy/" + Loader.getPlatform() + "/python/")}. */
-    public static File cachePackage() throws IOException {
+    public static synchronized File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
         Loader.load(scipy.class);
-        return Loader.cacheResource("/org/bytedeco/scipy/" + Loader.getPlatform() + "/python/");
+        packageFile = Loader.cacheResource("/org/bytedeco/scipy/" + Loader.getPlatform() + "/python/");
+        return packageFile;
     }
 
     /** Returns {@code {numpy.cachePackages(), scipy.cachePackage()}}. */

--- a/tensorflow/src/main/java/org/bytedeco/tensorflow/presets/tensorflow.java
+++ b/tensorflow/src/main/java/org/bytedeco/tensorflow/presets/tensorflow.java
@@ -430,17 +430,22 @@ import java.util.List;
 public class tensorflow implements BuildEnabled, LoadEnabled, InfoMapper {
     static { Loader.checkVersion("org.bytedeco", "tensorflow"); }
 
+    private static File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/tensorflow/" + Loader.getPlatform() + extension + "/python/")}. */
-    public static File cachePackage() throws IOException {
+    public static synchronized File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
         Loader.load(org.bytedeco.cpython.global.python.class);
         String path = Loader.load(tensorflow.class);
         if (path != null) {
             path = path.replace(File.separatorChar, '/');
             int i = path.indexOf("/org/bytedeco/tensorflow/" + Loader.getPlatform());
             int j = path.lastIndexOf("/");
-            return Loader.cacheResource(path.substring(i, j) + "/python/");
+            packageFile = Loader.cacheResource(path.substring(i, j) + "/python/");
         }
-        return null;
+        return packageFile;
     }
 
     /** Returns {@code {numpy.cachePackages(), tensorflow.cachePackage()}}. */

--- a/tvm/src/main/java/org/bytedeco/tvm/presets/tvm.java
+++ b/tvm/src/main/java/org/bytedeco/tvm/presets/tvm.java
@@ -62,8 +62,13 @@ import org.bytedeco.scipy.presets.*;
 public class tvm {
     static { Loader.checkVersion("org.bytedeco", "tvm"); }
 
+    private static File packageFile = null;
+
     /** Returns {@code Loader.cacheResource("/org/bytedeco/" + Loader.getPlatform() + extension + "/tvm/python/")}. */
-    public static File cachePackage() throws IOException {
+    public static synchronized File cachePackage() throws IOException {
+        if (packageFile != null) {
+            return packageFile;
+        }
         Loader.load(org.bytedeco.cpython.global.python.class);
         String path = Loader.load(tvm.class);
         if (path != null) {
@@ -72,9 +77,9 @@ public class tvm {
             int j = path.lastIndexOf("/");
             File f = Loader.cacheResource(path.substring(i, j) + "/python/");
             Loader.load(tvm_runtime.class);
-            return f;
+            packageFile = f;
         }
-        return null;
+        return packageFile;
     }
 
     /** Returns {@code {scipy.cachePackages(), tvm.cachePackage()}}. */


### PR DESCRIPTION
With this PR I suggest to store `pythonFile` computed in the `cpython.presets.python.cachePackage()` in a static variable and to return it if it is already computed to prevent caching of the python packages multiple times.
I assume the result should be the same in each call?

This method is called twice when using the embeddedpython.Python class (in a stripped variant) and each call takes at least one third of the 2 seconds initialization time of `embeddedpython.Python`. So also caching the path would speed up the initialization significantly.

Actually this method could be synchronized to prevent concurrent caching of the packages. If you agree I can update this PR accordingly.
