### PR TITLE
Fix rpath for LZ4 on Mac

### DIFF
--- a/lz4/cppbuild.sh
+++ b/lz4/cppbuild.sh
@@ -28,6 +28,8 @@ case $PLATFORM in
     macosx-x86_64)
         make -j $MAKEJ
         PREFIX=$INSTALL_PATH make install
+	# fix library with correct rpath
+        install_name_tool -add_rpath @loader_path/. -id @rpath/liblz4.1.dylib ../lib/liblz4.1.dylib
         ;;
     windows-x86)
         cd build/cmake


### PR DESCRIPTION
On Mac OS the library for LZ4 cannot be loaded:
```
java.lang.UnsatisfiedLinkError: no jnilz4 in java.library.path: [/Users/jenkins/Library/Java/Extensions, /Library/Java/Extensions, /Network/Library/Java/Extensions, /System/Library/Java/Extensions, /usr/lib/java, .]
	at java.base/java.lang.ClassLoader.loadLibrary(Unknown Source)
	at java.base/java.lang.Runtime.loadLibrary0(Unknown Source)
	at java.base/java.lang.System.loadLibrary(Unknown Source)
	at org.bytedeco.javacpp.Loader.loadLibrary(Loader.java:1762)
	at org.bytedeco.javacpp.Loader.load(Loader.java:1369)
	at org.bytedeco.javacpp.Loader.load(Loader.java:1181)
	at org.bytedeco.javacpp.Loader.load(Loader.java:1157)
	at org.bytedeco.lz4.global.lz4.<clinit>(lz4.java:14)
	at org.knime.core.columnar.arrow.compress.Lz4BlockCompressionCodec.doDecompress(Lz4BlockCompressionCodec.java:95)
	[...]
Caused by: java.lang.UnsatisfiedLinkError: /Users/jenkins/.javacpp/cache/macosx-x86_64/libjnilz4.dylib: dlopen(/Users/jenkins/.javacpp/cache/macosx-x86_64/libjnilz4.dylib, 1): Library not loaded: /usr/local/lib/liblz4.1.dylib
  Referenced from: /Users/jenkins/.javacpp/cache/macosx-x86_64/libjnilz4.dylib
  Reason: image not found
	at java.base/java.lang.ClassLoader$NativeLibrary.load0(Native Method)
	at java.base/java.lang.ClassLoader$NativeLibrary.load(Unknown Source)
	at java.base/java.lang.ClassLoader$NativeLibrary.loadLibrary(Unknown Source)
	at java.base/java.lang.ClassLoader.loadLibrary0(Unknown Source)
	at java.base/java.lang.ClassLoader.loadLibrary(Unknown Source)
	at java.base/java.lang.Runtime.load0(Unknown Source)
	at java.base/java.lang.System.load(Unknown Source)
	at org.bytedeco.javacpp.Loader.loadLibrary(Loader.java:1709)
	... 48 more
```

This PR fixes this problem by setting the rpath of liblz4 after the cpp build is done.