### PR TITLE
Update Maven Version For Triton Server README

### DIFF
--- a/.github/workflows/tritonserver.yml
+++ b/.github/workflows/tritonserver.yml
@@ -17,6 +17,6 @@ env:
 jobs:
   linux-x86_64:
     runs-on: ubuntu-18.04
-    container: nvcr.io/nvidia/tritonserver:21.09-py3
+    container: nvcr.io/nvidia/tritonserver:21.12-py3
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
  * Upgrade requirements to Android 7.0 for camera support in OpenCV and FFmpeg ([issue bytedeco/javacv#1692](https://github.com/bytedeco/javacv/issues/1692))
  * Include new `llvm-c/Transforms/PassBuilder.h` header file in presets for LLVM ([pull #1093](https://github.com/bytedeco/javacpp-presets/pull/1093))
  * Introduce `macosx-arm64` builds to presets for OpenBLAS, OpenCV ([issue #1069](https://github.com/bytedeco/javacpp-presets/issues/1069)), LLVM ([pull #1092](https://github.com/bytedeco/javacpp-presets/pull/1092))
- * Add presets for LZ4 1.9.3 ([pull #1094](https://github.com/bytedeco/javacpp-presets/pull/1094)), Triton Inference Server 2.14 ([pull #1085](https://github.com/bytedeco/javacpp-presets/pull/1085))
+ * Add presets for LZ4 1.9.3 ([pull #1094](https://github.com/bytedeco/javacpp-presets/pull/1094)), Triton Inference Server 2.17.0 ([pull #1085](https://github.com/bytedeco/javacpp-presets/pull/1085))
  * Add presets for the NvToolsExt (NVTX) module of CUDA ([issue #1068](https://github.com/bytedeco/javacpp-presets/issues/1068))
  * Increase the amount of function pointers available for callbacks in presets for Qt ([pull #1080](https://github.com/bytedeco/javacpp-presets/pull/1080))
  * Map C++ JIT classes and functions of TorchScript in presets for PyTorch ([issue #1068](https://github.com/bytedeco/javacpp-presets/issues/1068))

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Each child module in turn relies by default on the included [`cppbuild.sh` scrip
  * TensorFlow 1.15.x  https://github.com/tensorflow/tensorflow
  * TensorFlow Lite 2.7.x  https://github.com/tensorflow/tensorflow
  * TensorRT 8.x  https://developer.nvidia.com/tensorrt
- * Triton Inference Server 2.14  https://developer.nvidia.com/nvidia-triton-inference-server
+ * Triton Inference Server 2.17.x  https://developer.nvidia.com/nvidia-triton-inference-server
  * The Arcade Learning Environment 0.7.x  https://github.com/mgbellemare/Arcade-Learning-Environment
  * DepthAI 2.13.x  https://github.com/luxonis/depthai-core
  * ONNX 1.10.x  https://github.com/onnx/onnx

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -304,7 +304,7 @@
     <dependency>
       <groupId>org.bytedeco</groupId>
       <artifactId>tritonserver-platform</artifactId>
-      <version>2.14-${project.version}</version>
+      <version>2.17-${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/tritonserver/README.md
+++ b/tritonserver/README.md
@@ -64,7 +64,7 @@ Now, this `models` directory will be our model repository.
  $ docker run -it --gpus=all -v $(pwd):/workspace nvcr.io/nvidia/tritonserver:21.09-py3 bash
  $ apt update
  $ apt install -y openjdk-11-jdk
- $ wget https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
+ $ wget https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
  $ tar zxvf apache-maven-3.8.4-bin.tar.gz
  $ export PATH=/opt/tritonserver/apache-maven-3.8.4/bin:$PATH
  $ git clone https://github.com/bytedeco/javacpp-presets.git

--- a/tritonserver/README.md
+++ b/tritonserver/README.md
@@ -23,7 +23,7 @@ Introduction
 ------------
 This directory contains the JavaCPP Presets module for:
 
- * Triton Inference Server 2.14  https://github.com/triton-inference-server/server
+ * Triton Inference Server 2.17.0  https://github.com/triton-inference-server/server
 
 Please refer to the parent README.md file for more detailed information about the JavaCPP Presets.
 
@@ -51,9 +51,9 @@ This sample intends to show how to call the Java-mapped C API of Triton to execu
 
  1. Get the source code of Triton Inference Server to prepare the model repository:
 ```bash
- $ wget https://github.com/triton-inference-server/server/archive/refs/tags/v2.14.0.tar.gz
- $ tar zxvf v2.14.0.tar.gz
- $ cd server-2.14.0/docs/examples/model_repository
+ $ wget https://github.com/triton-inference-server/server/archive/refs/tags/v2.17.0.tar.gz
+ $ tar zxvf v2.17.0.tar.gz
+ $ cd server-2.17.0/docs/examples/model_repository
  $ mkdir models
  $ cd models; cp -a ../simple .
 ```

--- a/tritonserver/README.md
+++ b/tritonserver/README.md
@@ -61,7 +61,7 @@ Now, this `models` directory will be our model repository.
 
  2. Start the Docker container to run the sample (assuming we are under the `models` directory created above):
 ```bash
- $ docker run -it --gpus=all -v $(pwd):/workspace nvcr.io/nvidia/tritonserver:21.09-py3 bash
+ $ docker run -it --gpus=all -v $(pwd):/workspace nvcr.io/nvidia/tritonserver:21.12-py3 bash
  $ apt update
  $ apt install -y openjdk-11-jdk
  $ wget https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz

--- a/tritonserver/README.md
+++ b/tritonserver/README.md
@@ -64,9 +64,9 @@ Now, this `models` directory will be our model repository.
  $ docker run -it --gpus=all -v $(pwd):/workspace nvcr.io/nvidia/tritonserver:21.09-py3 bash
  $ apt update
  $ apt install -y openjdk-11-jdk
- $ wget https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
- $ tar zxvf apache-maven-3.8.3-bin.tar.gz
- $ export PATH=/opt/tritonserver/apache-maven-3.8.2/bin:$PATH
+ $ wget https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
+ $ tar zxvf apache-maven-3.8.4-bin.tar.gz
+ $ export PATH=/opt/tritonserver/apache-maven-3.8.4/bin:$PATH
  $ git clone https://github.com/bytedeco/javacpp-presets.git
  $ cd javacpp-presets/tritonserver/samples
  $ mvn compile exec:java -Djavacpp.platform=linux-x86_64 -Dexec.args="-r /workspace/models"

--- a/tritonserver/platform/pom.xml
+++ b/tritonserver/platform/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.bytedeco</groupId>
   <artifactId>tritonserver-platform</artifactId>
-  <version>2.14-${project.parent.version}</version>
+  <version>2.17-${project.parent.version}</version>
   <name>JavaCPP Presets Platform for Tritonserver</name>
 
   <properties>

--- a/tritonserver/platform/redist/pom.xml
+++ b/tritonserver/platform/redist/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.bytedeco</groupId>
   <artifactId>tritonserver-platform-redist</artifactId>
-  <version>2.14-${project.parent.version}</version>
+  <version>2.17-${project.parent.version}</version>
   <name>JavaCPP Presets Platform Redist for Tritonserver</name>
 
   <properties>

--- a/tritonserver/pom.xml
+++ b/tritonserver/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.bytedeco</groupId>
   <artifactId>tritonserver</artifactId>
-  <version>2.14-${project.parent.version}</version>
+  <version>2.17-${project.parent.version}</version>
   <name>JavaCPP Presets for Tritonserver</name>
 
   <dependencies>

--- a/tritonserver/samples/pom.xml
+++ b/tritonserver/samples/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>tritonserver-platform</artifactId>
-            <version>2.14-1.5.7-SNAPSHOT</version>
+            <version>2.17-1.5.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/tritonserver/src/main/java/org/bytedeco/tritonserver/presets/tritonserver.java
+++ b/tritonserver/src/main/java/org/bytedeco/tritonserver/presets/tritonserver.java
@@ -54,7 +54,7 @@ import org.bytedeco.tensorrt.presets.nvparsers;
             exclude = {"<cudaGL.h>", "<cuda_gl_interop.h>"},
             link = "tritonserver",
             includepath = {"/opt/tritonserver/include/triton/core/", "/opt/tritonserver/include/", "/usr/local/cuda/include/", "/usr/include"},
-            linkpath = {"/usr/local/cuda/lib/", "/opt/tritonserver/lib/"}
+            linkpath = {"/usr/local/cuda/lib64/", "/opt/tritonserver/lib/"}
         ),
         @Platform(
             value = "windows-x86_64",

--- a/tritonserver/src/main/java/org/bytedeco/tritonserver/presets/tritonserver.java
+++ b/tritonserver/src/main/java/org/bytedeco/tritonserver/presets/tritonserver.java
@@ -54,7 +54,7 @@ import org.bytedeco.tensorrt.presets.nvparsers;
             exclude = {"<cudaGL.h>", "<cuda_gl_interop.h>"},
             link = "tritonserver",
             includepath = {"/opt/tritonserver/include/triton/core/", "/opt/tritonserver/include/", "/usr/local/cuda/include/", "/usr/include"},
-            linkpath = {"/opt/tritonserver/lib/"}
+            linkpath = {"/usr/local/cuda/lib/", "/opt/tritonserver/lib/"}
         ),
         @Platform(
             value = "windows-x86_64",

--- a/tritonserver/src/main/java/org/bytedeco/tritonserver/presets/tritonserver.java
+++ b/tritonserver/src/main/java/org/bytedeco/tritonserver/presets/tritonserver.java
@@ -53,7 +53,7 @@ import org.bytedeco.tensorrt.presets.nvparsers;
             include = {"tritonserver.h", "tritonbackend.h", "tritonrepoagent.h"},
             exclude = {"<cudaGL.h>", "<cuda_gl_interop.h>"},
             link = "tritonserver",
-            includepath = {"/opt/tritonserver/include/triton/core/", "/opt/tritonserver/include/", "/usr/include"},
+            includepath = {"/opt/tritonserver/include/triton/core/", "/opt/tritonserver/include/", "/usr/local/cuda/include/", "/usr/include"},
             linkpath = {"/opt/tritonserver/lib/"}
         ),
         @Platform(


### PR DESCRIPTION
The old version is no longer available, so this ticket updates the Maven version in the README.