### PR TITLE
Change the absolute path to a relative path about postbuild.sh execute in pom.xml

### DIFF
--- a/mkl-dnn/pom.xml
+++ b/mkl-dnn/pom.xml
@@ -47,7 +47,7 @@
               <skip>${javacpp.compiler.skip}</skip>
               <buildCommand>
                 <program>bash</program>
-                <argument>${project.basedir}/postbuild.sh</argument>
+                <argument>postbuild.sh</argument>
               </buildCommand>
               <workingDirectory>${project.basedir}</workingDirectory>
             </configuration>

--- a/openblas/pom.xml
+++ b/openblas/pom.xml
@@ -77,7 +77,7 @@
               <skip>${javacpp.compiler.skip}</skip>
               <buildCommand>
                 <program>bash</program>
-                <argument>${project.basedir}/postbuild.sh</argument>
+                <argument>postbuild.sh</argument>
               </buildCommand>
               <workingDirectory>${project.basedir}</workingDirectory>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
               <skip>${javacpp.cppbuild.skip}</skip>
               <buildCommand>
                 <program>bash</program>
-                <argument>${project.basedir}/../cppbuild.sh</argument>
+                <argument>cppbuild.sh</argument>
                 <argument>install</argument>
                 <argument>${javacpp.moduleId}</argument>
                 <argument>-platform=${javacpp.platform}</argument>
@@ -267,7 +267,7 @@
               <skip>${javacpp.cppbuild.skip}</skip>
               <buildCommand>
                 <program>bash</program>
-                <argument>${project.basedir}/../cppbuild.sh</argument>
+                <argument>cppbuild.sh</argument>
                 <argument>clean</argument>
                 <argument>${javacpp.moduleId}</argument>
               </buildCommand>


### PR DESCRIPTION
I got error when building openblas using mingw on Windows.

Because, when i build on Windows, the maven variable(project.basedir)'s path separator is backslash, so bash can't find the shell file.