### PR TITLE
ci: update to ubuntu 20.04

### DIFF
--- a/.github/workflows/ale.yml
+++ b/.github/workflows/ale.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -39,6 +39,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/arpack-ng.yml
+++ b/.github/workflows/arpack-ng.yml
@@ -17,27 +17,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -55,6 +55,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -30,6 +30,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/artoolkitplus.yml
+++ b/.github/workflows/artoolkitplus.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -74,6 +74,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/bullet.yml
+++ b/.github/workflows/bullet.yml
@@ -16,32 +16,32 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -59,6 +59,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/caffe.yml
+++ b/.github/workflows/caffe.yml
@@ -17,12 +17,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -38,6 +38,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   redeploy:
     needs: [linux-x86, linux-x86_64, macosx-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/chilitags.yml
+++ b/.github/workflows/chilitags.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -74,6 +74,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/cminpack.yml
+++ b/.github/workflows/cminpack.yml
@@ -17,27 +17,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -55,6 +55,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/cpu_features.yml
+++ b/.github/workflows/cpu_features.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -74,6 +74,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/cpython.yml
+++ b/.github/workflows/cpython.yml
@@ -16,27 +16,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -54,6 +54,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -17,17 +17,17 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -42,6 +42,6 @@ jobs:
   redeploy:
     needs: [linux-arm64, linux-ppc64le, linux-x86_64, windows-x86_64]
 #    needs: [linux-ppc64le, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/depthai.yml
+++ b/.github/workflows/depthai.yml
@@ -16,22 +16,22 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -41,6 +41,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-x86, linux-x86_64, macosx-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/dnnl.yml
+++ b/.github/workflows/dnnl.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -35,6 +35,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/ffmpeg.yml
+++ b/.github/workflows/ffmpeg.yml
@@ -17,7 +17,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     strategy:
       matrix:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     strategy:
       matrix:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     strategy:
       matrix:
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -118,6 +118,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/fftw.yml
+++ b/.github/workflows/fftw.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -74,6 +74,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/flandmark.yml
+++ b/.github/workflows/flandmark.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -74,6 +74,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/flycapture.yml
+++ b/.github/workflows/flycapture.yml
@@ -16,22 +16,22 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -45,6 +45,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-x86, linux-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/gsl.yml
+++ b/.github/workflows/gsl.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -74,6 +74,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/gym.yml
+++ b/.github/workflows/gym.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions

--- a/.github/workflows/hdf5.yml
+++ b/.github/workflows/hdf5.yml
@@ -16,27 +16,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -54,6 +54,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/hyperscan.yml
+++ b/.github/workflows/hyperscan.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -30,6 +30,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/leptonica.yml
+++ b/.github/workflows/leptonica.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -78,6 +78,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/libdc1394.yml
+++ b/.github/workflows/libdc1394.yml
@@ -16,27 +16,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -54,6 +54,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -78,6 +78,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/libfreenect.yml
+++ b/.github/workflows/libfreenect.yml
@@ -16,27 +16,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -54,6 +54,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/libfreenect2.yml
+++ b/.github/workflows/libfreenect2.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -35,6 +35,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/libpostal.yml
+++ b/.github/workflows/libpostal.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -39,6 +39,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/librealsense.yml
+++ b/.github/workflows/librealsense.yml
@@ -16,22 +16,22 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -49,6 +49,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/librealsense2.yml
+++ b/.github/workflows/librealsense2.yml
@@ -16,22 +16,22 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -49,6 +49,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/liquidfun.yml
+++ b/.github/workflows/liquidfun.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -39,6 +39,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -16,27 +16,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -62,14 +62,14 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions
   samples:
     needs: redeploy
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lz4.yml
+++ b/.github/workflows/lz4.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -39,6 +39,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/mkl-dnn.yml
+++ b/.github/workflows/mkl-dnn.yml
@@ -17,7 +17,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -31,6 +31,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/mkl.yml
+++ b/.github/workflows/mkl.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -39,6 +39,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/modsecurity.yml
+++ b/.github/workflows/modsecurity.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -26,6 +26,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/mxnet.yml
+++ b/.github/workflows/mxnet.yml
@@ -17,12 +17,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       fail-fast: false
@@ -53,6 +53,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/ngraph.yml
+++ b/.github/workflows/ngraph.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -26,6 +26,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -17,27 +17,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -55,6 +55,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/nvcodec.yml
+++ b/.github/workflows/nvcodec.yml
@@ -17,17 +17,17 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -37,6 +37,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-arm64, linux-ppc64le, linux-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/onnx.yml
+++ b/.github/workflows/onnx.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -30,6 +30,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/onnxruntime.yml
+++ b/.github/workflows/onnxruntime.yml
@@ -17,12 +17,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -45,6 +45,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/openblas.yml
+++ b/.github/workflows/openblas.yml
@@ -17,22 +17,22 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -45,27 +45,27 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -87,6 +87,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, ios-arm64, ios-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/opencl.yml
+++ b/.github/workflows/opencl.yml
@@ -16,12 +16,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -35,6 +35,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/opencv.yml
+++ b/.github/workflows/opencv.yml
@@ -17,22 +17,22 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -45,27 +45,27 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -93,6 +93,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, ios-arm64, ios-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/openpose.yml
+++ b/.github/workflows/openpose.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -26,6 +26,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -18,7 +18,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -61,6 +61,6 @@ jobs:
         timeout-minutes: 350
   redeploy:
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/qt.yml
+++ b/.github/workflows/qt.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -30,6 +30,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/scipy.yml
+++ b/.github/workflows/scipy.yml
@@ -17,27 +17,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -55,6 +55,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/skia.yml
+++ b/.github/workflows/skia.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
@@ -39,6 +39,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   redeploy:
     needs: [ios-arm64, ios-x86_64, linux-x86, linux-x86_64, macosx-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/spinnaker.yml
+++ b/.github/workflows/spinnaker.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -30,6 +30,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -16,27 +16,27 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -54,6 +54,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/tensorflow-lite.yml
+++ b/.github/workflows/tensorflow-lite.yml
@@ -16,32 +16,32 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -55,6 +55,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -18,32 +18,32 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -73,6 +73,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-x86, linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/tensorrt.yml
+++ b/.github/workflows/tensorrt.yml
@@ -17,12 +17,12 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -32,6 +32,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-arm64, linux-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/tesseract.yml
+++ b/.github/workflows/tesseract.yml
@@ -16,47 +16,47 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   android-arm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   android-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-ppc64le:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
@@ -78,6 +78,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-ppc64le, linux-x86, linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/tritonserver.yml
+++ b/.github/workflows/tritonserver.yml
@@ -16,7 +16,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: nvcr.io/nvidia/tritonserver:22.07-py3
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions

--- a/.github/workflows/tvm.yml
+++ b/.github/workflows/tvm.yml
@@ -17,7 +17,7 @@ env:
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container: centos:7
     strategy:
       matrix:
@@ -40,6 +40,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/videoinput.yml
+++ b/.github/workflows/videoinput.yml
@@ -25,6 +25,6 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
     needs: [windows-x86, windows-x86_64]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions


### PR DESCRIPTION
Prospective change for CI, in response to GH deprecating Ubuntu 18.04.