### PR TITLE
Added build support for librealsense2 on Apple Silicon arm64

### DIFF
--- a/.github/workflows/librealsense2.yml
+++ b/.github/workflows/librealsense2.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   macosx-arm64:
-    runs-on: macos-12
+    runs-on: macos-11
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   windows-x86:

--- a/.github/workflows/librealsense2.yml
+++ b/.github/workflows/librealsense2.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   macosx-arm64:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   windows-x86:

--- a/.github/workflows/librealsense2.yml
+++ b/.github/workflows/librealsense2.yml
@@ -41,6 +41,10 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
+  macosx-arm64:
+    runs-on: macos-11
+    steps:
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   windows-x86:
     runs-on: windows-2019
     steps:
@@ -50,7 +54,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
-    needs: [linux-armhf, linux-arm64, linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
+    needs: [linux-armhf, linux-arm64, linux-x86, linux-x86_64, macosx-x86_64, macosx-arm64, windows-x86, windows-x86_64]
     runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/librealsense2/cppbuild.sh
+++ b/librealsense2/cppbuild.sh
@@ -8,7 +8,7 @@ if [[ -z "$PLATFORM" ]]; then
 fi
 
 LIBREALSENSE2_VERSION=2.50.0
-LIBUSB_VERSION=1.0.22
+LIBUSB_VERSION=1.0.26
 download https://github.com/IntelRealSense/librealsense/archive/v$LIBREALSENSE2_VERSION.tar.gz librealsense-$LIBREALSENSE2_VERSION.tar.gz
 download http://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-$LIBUSB_VERSION/libusb-$LIBUSB_VERSION.tar.bz2/download libusb-$LIBUSB_VERSION.tar.bz2
 
@@ -70,6 +70,13 @@ case $PLATFORM in
         make -j $MAKEJ
         make install/strip
         install_name_tool -change /usr/local/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib ../lib/librealsense2.dylib
+        ;;
+    macosx-arm64)
+        "$CMAKE" -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_MACOSX_RPATH=ON -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_GRAPHICAL_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_THREAD_LIBS_INIT="-lpthread" -DBUILD_WITH_OPENMP=false -DCMAKE_OSX_DEPLOYMENT_TARGET=11 -DHWM_OVER_XU=false -G Xcode .
+        xcodebuild -scheme realsense2 -configuration Release MACOSX_DEPLOYMENT_TARGET=11
+        cp -a Release/*.dylib "$INSTALL_PATH/lib"
+        cp -a include/* "$INSTALL_PATH/include"
+        install_name_tool -change /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib ../lib/librealsense2.dylib
         ;;
     windows-x86)
         mkdir -p build

--- a/librealsense2/cppbuild.sh
+++ b/librealsense2/cppbuild.sh
@@ -72,11 +72,10 @@ case $PLATFORM in
         install_name_tool -change /usr/local/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib ../lib/librealsense2.dylib
         ;;
     macosx-arm64)
-        "$CMAKE" -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_MACOSX_RPATH=ON -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_GRAPHICAL_EXAMPLES=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_THREAD_LIBS_INIT="-lpthread" -DBUILD_WITH_OPENMP=false -DCMAKE_OSX_DEPLOYMENT_TARGET=11 -DHWM_OVER_XU=false -G Xcode .
-        xcodebuild -scheme realsense2 -configuration Release MACOSX_DEPLOYMENT_TARGET=11
-        cp -a Release/*.dylib "$INSTALL_PATH/lib"
-        cp -a include/* "$INSTALL_PATH/include"
-        install_name_tool -change /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib ../lib/librealsense2.dylib
+        "$CMAKE" -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH" -DCMAKE_MACOSX_RPATH=ON -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_GRAPHICAL_EXAMPLES=OFF -DCMAKE_THREAD_LIBS_INIT="-lpthread" -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false .
+        make -j $MAKEJ
+        make install/strip
+        install_name_tool -change /usr/local/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib ../lib/librealsense2.dylib
         ;;
     windows-x86)
         mkdir -p build

--- a/librealsense2/platform/pom.xml
+++ b/librealsense2/platform/pom.xml
@@ -64,6 +64,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
+      <classifier>${javacpp.platform.macosx-arm64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
       <classifier>${javacpp.platform.windows-x86}</classifier>
     </dependency>
     <dependency>
@@ -134,6 +140,7 @@
                       requires static org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires static org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires static org.bytedeco.${javacpp.moduleId}.macosx.x86_64;
+                      requires static org.bytedeco.${javacpp.moduleId}.macosx.arm64;
                       requires static org.bytedeco.${javacpp.moduleId}.windows.x86;
                       requires static org.bytedeco.${javacpp.moduleId}.windows.x86_64;
                     }

--- a/librealsense2/src/main/java/org/bytedeco/librealsense2/presets/realsense2.java
+++ b/librealsense2/src/main/java/org/bytedeco/librealsense2/presets/realsense2.java
@@ -38,7 +38,7 @@ import org.bytedeco.javacpp.tools.InfoMapper;
     inherit = javacpp.class,
     value = {
         @Platform(
-            value = {"linux-armhf", "linux-arm64", "linux-x86", "macosx-x86", "windows-x86"},
+            value = {"linux-armhf", "linux-arm64", "linux-x86", "macosx-x86", "macosx-arm64", "windows-x86"},
             compiler = "cpp11",
             include = {
                 "librealsense2/h/rs_types.h",

--- a/pom.xml
+++ b/pom.xml
@@ -1453,6 +1453,7 @@
         <module>libffi</module>
         <module>libpostal</module>
         <module>leptonica</module>
+        <module>librealsense2</module>
         <module>tesseract</module>
       </modules>
       <properties>


### PR DESCRIPTION
This PR adds build support for Apple Silicon arm64 using the XCode build system as recommended [here](https://lightbuzz.com/realsense-macos/) and [here](https://github.com/cansik/pyrealsense2-macosx).