### PR TITLE
Add macosx-arm64 preset for lz4

### DIFF
--- a/.github/workflows/lz4.yml
+++ b/.github/workflows/lz4.yml
@@ -31,6 +31,10 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
+  macosx-arm64:
+    runs-on: macos-11
+    steps:
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   windows-x86:
     runs-on: windows-2019
     steps:
@@ -40,7 +44,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
-    needs: [linux-x86, linux-x86_64, macosx-x86_64, windows-x86, windows-x86_64]
+    needs: [linux-x86, linux-x86_64, macosx-x86_64, macosx-arm64, windows-x86, windows-x86_64]
     runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/lz4/cppbuild.sh
+++ b/lz4/cppbuild.sh
@@ -31,6 +31,12 @@ case $PLATFORM in
 	# fix library with correct rpath
         install_name_tool -add_rpath @loader_path/. -id @rpath/liblz4.1.dylib ../lib/liblz4.1.dylib
         ;;
+    macosx-arm64)
+        make -j $MAKEJ
+        PREFIX=$INSTALL_PATH make install
+	# fix library with correct rpath
+        install_name_tool -add_rpath @loader_path/. -id @rpath/liblz4.1.dylib ../lib/liblz4.1.dylib
+        ;;
     windows-x86)
         cd build/cmake
         export CC="cl.exe"

--- a/lz4/platform/pom.xml
+++ b/lz4/platform/pom.xml
@@ -52,6 +52,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
+      <classifier>${javacpp.platform.macosx-arm64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
       <classifier>${javacpp.platform.windows-x86}</classifier>
     </dependency>
     <dependency>
@@ -72,7 +78,7 @@
             <configuration>
               <archive>
                 <manifestEntries>
-                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-x86.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-windows-x86.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
+                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-x86.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-macosx-arm64.jar ${javacpp.moduleId}-windows-x86.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
                 </manifestEntries>
               </archive>
             </configuration>
@@ -120,6 +126,7 @@
                       requires static org.bytedeco.${javacpp.moduleId}.linux.x86;
                       requires static org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires static org.bytedeco.${javacpp.moduleId}.macosx.x86_64;
+                      requires static org.bytedeco.${javacpp.moduleId}.macosx.arm64;
                       requires static org.bytedeco.${javacpp.moduleId}.windows.x86;
                       requires static org.bytedeco.${javacpp.moduleId}.windows.x86_64;
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -1453,6 +1453,7 @@
         <module>libffi</module>
         <module>libpostal</module>
         <module>leptonica</module>
+        <module>lz4</module>
         <module>tesseract</module>
       </modules>
       <properties>


### PR DESCRIPTION
This PR enables the build of the macosx-arm64 preset for lz4.

Build is working, please let me know if anything else is missing.