### PR TITLE
Add build for tensorflow-lite for platform linux-armhf

### DIFF
--- a/.github/workflows/tensorflow-lite.yml
+++ b/.github/workflows/tensorflow-lite.yml
@@ -47,6 +47,11 @@ jobs:
     container: ubuntu:bionic
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
+  linux-x86:
+    runs-on: ubuntu-20.04
+    container: centos:7
+    steps:
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
   linux-x86_64:
     runs-on: ubuntu-20.04
     container: centos:7
@@ -61,7 +66,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
-    needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
+    needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-x86, linux-x86_64, macosx-x86_64, windows-x86_64]
     runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/.github/workflows/tensorflow-lite.yml
+++ b/.github/workflows/tensorflow-lite.yml
@@ -37,6 +37,11 @@ jobs:
     container: centos:7
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-centos@actions
+  linux-armhf:
+    runs-on: ubuntu-20.04
+    container: ubuntu:bionic
+    steps:
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-arm64:
     runs-on: ubuntu-20.04
     container: ubuntu:bionic
@@ -56,7 +61,7 @@ jobs:
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
   redeploy:
-    needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
+    needs: [android-arm, android-arm64, android-x86, android-x86_64, linux-armhf, linux-arm64, linux-x86_64, macosx-x86_64, windows-x86_64]
     runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Introduce `linux-armhf` and `linux-x86` builds to presets for TensorFlow Lite ([pull #1268](https://github.com/bytedeco/javacpp-presets/pull/1268))
  * Add presets for LibRaw 0.20.2 ([pull #1211](https://github.com/bytedeco/javacpp-presets/pull/1211))
  * Upgrade presets for PyTorch 1.13.0, and their dependencies
 

--- a/pom.xml
+++ b/pom.xml
@@ -1131,8 +1131,8 @@
         <module>llvm</module>
         <module>libffi</module>
         <module>leptonica</module>
-        <module>tensorflow-lite</module>
         <module>tesseract</module>
+        <module>tensorflow-lite</module>
         <module>depthai</module>
         <module>cpu_features</module>
         <module>systems</module>
@@ -1322,6 +1322,7 @@
         <module>caffe</module>
         <module>mxnet</module>
         <module>tensorflow</module>
+        <module>tensorflow-lite</module>
         <module>ale</module>
         <module>depthai</module>
         <module>bullet</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1131,6 +1131,7 @@
         <module>llvm</module>
         <module>libffi</module>
         <module>leptonica</module>
+        <module>tensorflow-lite</module>
         <module>tesseract</module>
         <module>depthai</module>
         <module>cpu_features</module>

--- a/tensorflow-lite/platform/pom.xml
+++ b/tensorflow-lite/platform/pom.xml
@@ -54,6 +54,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-armhf}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
       <classifier>${javacpp.platform.linux-arm64}</classifier>
     </dependency>
     <dependency>
@@ -86,7 +92,7 @@
             <configuration>
               <archive>
                 <manifestEntries>
-                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-arm64.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
+                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-arm64.jar ${javacpp.moduleId}-linux-armhf.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
                 </manifestEntries>
               </archive>
             </configuration>
@@ -136,6 +142,7 @@
 //                      requires static org.bytedeco.${javacpp.moduleId}.android.x86;
 //                      requires static org.bytedeco.${javacpp.moduleId}.android.x86_64;
                       requires static org.bytedeco.${javacpp.packageName}.linux.arm64;
+                      requires static org.bytedeco.${javacpp.packageName}.linux.armhf;
                       requires static org.bytedeco.${javacpp.packageName}.linux.x86_64;
                       requires static org.bytedeco.${javacpp.packageName}.macosx.x86_64;
                       requires static org.bytedeco.${javacpp.packageName}.windows.x86_64;

--- a/tensorflow-lite/platform/pom.xml
+++ b/tensorflow-lite/platform/pom.xml
@@ -66,6 +66,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-x86}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
     <dependency>
@@ -92,7 +98,7 @@
             <configuration>
               <archive>
                 <manifestEntries>
-                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-arm64.jar ${javacpp.moduleId}-linux-armhf.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
+                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-armhf.jar ${javacpp.moduleId}-linux-arm64.jar ${javacpp.moduleId}-linux-x86.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
                 </manifestEntries>
               </archive>
             </configuration>
@@ -141,8 +147,9 @@
 //                      requires static org.bytedeco.${javacpp.moduleId}.android.arm64;
 //                      requires static org.bytedeco.${javacpp.moduleId}.android.x86;
 //                      requires static org.bytedeco.${javacpp.moduleId}.android.x86_64;
-                      requires static org.bytedeco.${javacpp.packageName}.linux.arm64;
                       requires static org.bytedeco.${javacpp.packageName}.linux.armhf;
+                      requires static org.bytedeco.${javacpp.packageName}.linux.arm64;
+                      requires static org.bytedeco.${javacpp.packageName}.linux.x86;
                       requires static org.bytedeco.${javacpp.packageName}.linux.x86_64;
                       requires static org.bytedeco.${javacpp.packageName}.macosx.x86_64;
                       requires static org.bytedeco.${javacpp.packageName}.windows.x86_64;


### PR DESCRIPTION
Most of the job was already done.
The build script was already prepared.
This only adds the platform on the pom and the for tensorflow-lite and on the main pom.
And updates the git flow to do the build and release.