### PR TITLE
ffmpeg: add kvazaar support

### DIFF
--- a/.github/actions/deploy-centos/action.yml
+++ b/.github/actions/deploy-centos/action.yml
@@ -24,7 +24,7 @@ runs:
         if [[ "$CENTOS_VERSION" == "6" ]]; then
           sed -i 's/mirror\.centos\.org\/centos/vault.centos.org/g;s/6\/sclo/6.10\/sclo/g;s/mirrorlist/#mirrorlist/g;s/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
         fi
-        yum -y install $SCL_ENABLE rh-java-common-ant boost-devel ccache clang gcc-c++ gcc-gfortran java-1.8.0-openjdk-devel ant python python3-devel python3-pip swig file which wget unzip tar bzip2 gzip xz patch autoconf-archive automake make libtool bison flex perl-core nasm alsa-lib-devel freeglut-devel gtk2-devel libusb-devel libusb1-devel curl-devel expat-devel gettext-devel openssl-devel bzip2-devel zlib-devel SDL2-devel libva-devel libxkbcommon-devel libxkbcommon-x11-devel xcb-util* fontconfig-devel libffi-devel ragel ocl-icd-devel GeoIP-devel pcre-devel ssdeep-devel yajl-devel
+        yum -y install $SCL_ENABLE rh-java-common-ant boost-devel ccache clang gcc-c++ gcc-gfortran java-1.8.0-openjdk-devel ant python python3-devel python3-pip swig file which wget unzip tar bzip2 gzip xz patch autoconf-archive automake make libtool bison flex perl-core nasm alsa-lib-devel freeglut-devel gtk2-devel libusb-devel libusb1-devel curl-devel expat-devel gettext-devel openssl-devel bzip2-devel zlib-devel SDL2-devel libva-devel libxkbcommon-devel libxkbcommon-x11-devel xcb-util* fontconfig-devel libffi-devel ragel ocl-icd-devel GeoIP-devel pcre-devel ssdeep-devel yajl-devel yasm
         # https://gcc.gnu.org/legacy-ml/gcc-patches/2018-01/msg01962.html
         sed -i 's/_mm512_abs_pd (__m512 __A)/_mm512_abs_pd (__m512d __A)/g' /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/include/avx512fintrin.h
         source scl_source enable $SCL_ENABLE || true

--- a/.github/actions/deploy-macosx/action.yml
+++ b/.github/actions/deploy-macosx/action.yml
@@ -23,7 +23,7 @@ runs:
         fi
 
         brew uninstall --force --ignore-dependencies gcc gcc@7 gcc@8 gcc@9 gcc@10 gcc@11 gcc@12 little-cms2 maven openblas r
-        brew install boost ccache swig autoconf-archive automake cmake libomp libtool libusb ant nasm xz pkg-config sdl2 gpg1 bison flex perl ragel binutils gradle gmp isl libmpc mpfr geoip pcre ssdeep yajl
+        brew install boost ccache swig autoconf-archive automake cmake libomp libtool libusb ant nasm xz pkg-config sdl2 gpg1 bison flex perl ragel binutils gradle gmp isl libmpc mpfr geoip pcre ssdeep yajl yasm
         brew link --force libomp
 
         if [[ -n ${CI_DEPLOY_NEED_GCC:-} ]]; then

--- a/.github/actions/deploy-ubuntu/action.yml
+++ b/.github/actions/deploy-ubuntu/action.yml
@@ -68,7 +68,7 @@ runs:
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BA6932366A755776
         apt-get update
         apt-get -y install gcc-multilib g++-multilib python3 python2.7 python3-minimal python2.7-minimal rpm libasound2-dev:$ARCH freeglut3-dev:$ARCH libfontconfig-dev:$ARCH libgtk2.0-dev:$ARCH libusb-dev:$ARCH libusb-1.0-0-dev:$ARCH libffi-dev:$ARCH libbz2-dev:$ARCH zlib1g-dev:$ARCH libxcb1-dev:$ARCH
-        apt-get -y install pkg-config ccache clang $TOOLCHAIN openjdk-8-jdk-headless ant python python3-pip swig git file wget unzip tar bzip2 gzip patch autoconf-archive autogen automake make libtool bison flex perl nasm curl libcurl4-openssl-dev libssl-dev libffi-dev libbz2-dev zlib1g-dev
+        apt-get -y install pkg-config ccache clang $TOOLCHAIN openjdk-8-jdk-headless ant python python3-pip swig git file wget unzip tar bzip2 gzip patch autoconf-archive autogen automake make libtool bison flex perl nasm curl libcurl4-openssl-dev libssl-dev libffi-dev libbz2-dev yasm zlib1g-dev
 
         find /usr/lib/jvm/default-java/
         curl -LO https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-Linux-x86_64.tar.gz

--- a/.github/actions/deploy-windows/action.yml
+++ b/.github/actions/deploy-windows/action.yml
@@ -10,7 +10,7 @@ runs:
         echo Installing MSYS2
         C:\msys64\usr\bin\bash -lc "pacman -S --needed --noconfirm pkg-config"
         C:\msys64\usr\bin\bash -lc "pacman -S --needed --noconfirm base-devel git tar unzip p7zip zip autoconf autoconf-archive automake libtool make patch gnupg"
-        C:\msys64\usr\bin\bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-nasm mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool mingw-w64-x86_64-gcc mingw-w64-i686-gcc mingw-w64-x86_64-gcc-fortran mingw-w64-i686-gcc-fortran mingw-w64-x86_64-libwinpthread-git mingw-w64-i686-libwinpthread-git mingw-w64-x86_64-SDL2 mingw-w64-i686-SDL2 mingw-w64-x86_64-ragel"
+        C:\msys64\usr\bin\bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-nasm mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool mingw-w64-x86_64-gcc mingw-w64-i686-gcc mingw-w64-x86_64-gcc-fortran mingw-w64-i686-gcc-fortran mingw-w64-x86_64-libwinpthread-git mingw-w64-i686-libwinpthread-git mingw-w64-x86_64-SDL2 mingw-w64-i686-SDL2 mingw-w64-x86_64-ragel mingw-w64-x86_64-yasm"
         set "PATH=C:\msys64\usr\bin;%PATH%"
 
         echo Installing Windows SDK 8.1
@@ -278,14 +278,14 @@ runs:
         set "MAVEN_OPTIONS=clean %MAVEN_PHASE% -B -U -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3 -Djavacpp.platform=%CI_DEPLOY_PLATFORM% -Djavacpp.platform.extension=%EXT% %MAVEN_OPTIONS% %CI_DEPLOY_OPTIONS%"
 
         setlocal enabledelayedexpansion
-        for /l %%i in (1,1,5) do (set STATUS=0 & call mvn %MAVEN_OPTIONS% -pl .,%CI_DEPLOY_MODULE% && goto :done || set STATUS=!ERRORLEVEL! && timeout 60 > nul)
+        for /l %%i in (1,1,1) do (set STATUS=0 & call mvn %MAVEN_OPTIONS% -pl .,%CI_DEPLOY_MODULE% && goto :done || set STATUS=!ERRORLEVEL! && timeout 60 > nul)
         exit /b !STATUS!
         :done
-        for /l %%i in (1,1,5) do (set STATUS=0 & call mvn %MAVEN_OPTIONS% -f %CI_DEPLOY_MODULE%/platform/%EXT2%/pom.xml && goto :done2 || set STATUS=!ERRORLEVEL! && timeout 60 > nul)
+        for /l %%i in (1,1,1) do (set STATUS=0 & call mvn %MAVEN_OPTIONS% -f %CI_DEPLOY_MODULE%/platform/%EXT2%/pom.xml && goto :done2 || set STATUS=!ERRORLEVEL! && timeout 60 > nul)
         exit /b !STATUS!
         :done2
         if exist %CI_DEPLOY_MODULE%/platform/redist/pom.xml (
-          for /l %%i in (1,1,5) do (set STATUS=0 & call mvn %MAVEN_OPTIONS% -f %CI_DEPLOY_MODULE%/platform/redist/pom.xml && goto :done3 || set STATUS=!ERRORLEVEL! && timeout 60 > nul)
+          for /l %%i in (1,1,1) do (set STATUS=0 & call mvn %MAVEN_OPTIONS% -f %CI_DEPLOY_MODULE%/platform/redist/pom.xml && goto :done3 || set STATUS=!ERRORLEVEL! && timeout 60 > nul)
           exit /b !STATUS!
         )
         :done3

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -109,6 +109,7 @@ export PKG_CONFIG_PATH=$INSTALL_PATH/lib/pkgconfig/
 
 patch -Np1 -d $LAME < ../../lame.patch
 patch -Np1 -d $OPENSSL < ../../openssl-android.patch
+patch -Np1 -d kvazaar-$KVAZAAR_VERSION < ../../kvazaar.patch
 patch -Np1 -d ffmpeg-$FFMPEG_VERSION < ../../ffmpeg.patch
 patch -Np1 -d ffmpeg-$FFMPEG_VERSION < ../../ffmpeg-flv-support-hevc-opus.patch
 sedinplace 's/bool bEnableavx512/bool bEnableavx512 = false/g' x265-*/source/common/param.h

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -372,7 +372,7 @@ EOF
         make install
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared --host=aarch64-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=aarch64-linux
         make -j $MAKEJ
         make install
 
@@ -633,7 +633,7 @@ EOF
         make install
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared --host=x86_64-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-linux
         make -j $MAKEJ
         make install
 

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -1804,7 +1804,7 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32 || cat config.log
+        CC="clang -D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install
 
@@ -1928,7 +1928,7 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32 || cat config.log
+        CC="clang -D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install
 

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -1521,7 +1521,7 @@ EOF
         make install
         
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --host=aarch64-apple-darwin
         make -j $MAKEJ
         make install
         

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -42,7 +42,8 @@ NVCODEC_VERSION=11.1.5.1
 XML2=libxml2-2.9.12
 LIBSRT_VERSION=1.5.0
 WEBP_VERSION=1.2.4
-KVAZAAR_VERSION=2.1.0
+KVAZAAR_VERSION=a4005046ae2ebb3c88e92ff06736ce57b60fdcc7
+# https://codeload.github.com/ultravideo/kvazaar/zip/a4005046ae2ebb3c88e92ff06736ce57b60fdcc7
 FFMPEG_VERSION=5.1.2
 download https://download.videolan.org/contrib/nasm/nasm-$NASM_VERSION.tar.gz nasm-$NASM_VERSION.tar.gz
 download http://zlib.net/$ZLIB.tar.gz $ZLIB.tar.gz
@@ -63,7 +64,7 @@ download http://xmlsoft.org/sources/$XML2.tar.gz $XML2.tar.gz
 download https://github.com/Haivision/srt/archive/refs/tags/v$LIBSRT_VERSION.tar.gz srt-$LIBSRT_VERSION.tar.gz
 download https://github.com/FFmpeg/nv-codec-headers/archive/n$NVCODEC_VERSION.tar.gz nv-codec-headers-$NVCODEC_VERSION.tar.gz
 download https://github.com/webmproject/libwebp/archive/refs/tags/v$WEBP_VERSION.tar.gz libwebp-$WEBP_VERSION.tar.gz
-download https://github.com/ultravideo/kvazaar/releases/download/v$KVAZAAR_VERSION/kvazaar-$KVAZAAR_VERSION.tar.gz kvazaar-$KVAZAAR_VERSION.tar.gz
+download https://codeload.github.com/ultravideo/kvazaar/zip/a4005046ae2ebb3c88e92ff06736ce57b60fdcc7 kvazaar-$KVAZAAR_VERSION.zip
 download http://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.bz2 ffmpeg-$FFMPEG_VERSION.tar.bz2
 
 mkdir -p $PLATFORM$EXTENSION
@@ -88,7 +89,7 @@ tar --totals -xzf ../mfx_dispatch-$MFX_VERSION.tar.gz
 tar --totals -xzf ../nv-codec-headers-$NVCODEC_VERSION.tar.gz
 tar --totals -xzf ../$XML2.tar.gz
 tar --totals -xzf ../libwebp-$WEBP_VERSION.tar.gz
-tar --totals -xzf ../kvazaar-$KVAZAAR_VERSION.tar.gz
+unzip -qo ../kvazaar-$KVAZAAR_VERSION.zip
 tar --totals -xjf ../ffmpeg-$FFMPEG_VERSION.tar.bz2
 
 if [[ "${ACLOCAL_PATH:-}" == C:\\msys64\\* ]]; then
@@ -239,6 +240,13 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=arm-linux
         make -j $MAKEJ
         make install
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=arm-linux
+        make -j $MAKEJ
+        make install
+
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=arm --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
@@ -370,6 +378,13 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=aarch64-linux
         make -j $MAKEJ
         make install
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-linux
+        make -j $MAKEJ
+        make install
+
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=aarch64 --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
@@ -498,6 +513,13 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=i686-linux
         make -j $MAKEJ
         make install
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=i686-linux
+        make -j $MAKEJ
+        make install
+
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
@@ -625,6 +647,13 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=x86_64-linux
         make -j $MAKEJ
         make install
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=x86_64-linux
+        make -j $MAKEJ
+        make install
+
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
@@ -753,6 +782,7 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
         CC="gcc -m32 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-linux
         make -j $MAKEJ
         make install
@@ -884,6 +914,7 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
         CC="gcc -m64 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared
         make -j $MAKEJ
         make install
@@ -1065,7 +1096,8 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        CC="arm-linux-gnueabihf-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared --host=arm-linux-gnueabihf
+        ./autogen.sh
+        CC="arm-linux-gnueabihf-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=arm-linux-gnueabihf
         make -j $MAKEJ
         make install
 
@@ -1204,7 +1236,8 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        CC="aarch64-linux-gnu-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared --host=aarch64-linux-gnu
+        ./autogen.sh
+        CC="aarch64-linux-gnu-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=aarch64-linux-gnu
         make -j $MAKEJ
         make install
 
@@ -1399,6 +1432,7 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
         sed -i s/elf64ppc/elf64lppc/ configure
         if [[ "$MACHINE_TYPE" =~ ppc64 ]]; then
           CC="gcc -m64" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared
@@ -1527,7 +1561,8 @@ EOF
         make install
         
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --host=aarch64-apple-darwin
+        ./autogen.sh
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-apple-darwin
         make -j $MAKEJ
         make install
         
@@ -1643,6 +1678,7 @@ EOF
         make install
                 
         cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic
         make -j $MAKEJ
         make install
@@ -1767,6 +1803,7 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32
         make -j $MAKEJ
         make install
@@ -1890,6 +1927,7 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
+        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32
         make -j $MAKEJ
         make install

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -370,12 +370,6 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=aarch64-linux
         make -j $MAKEJ
         make install
-
-        cd ../kvazaar-$KVAZAAR_VERSION
-        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=aarch64-linux
-        make -j $MAKEJ
-        make install
-
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=aarch64 --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
@@ -631,12 +625,6 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=x86_64-linux
         make -j $MAKEJ
         make install
-
-        cd ../kvazaar-$KVAZAAR_VERSION
-        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-linux
-        make -j $MAKEJ
-        make install
-
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
@@ -762,6 +750,12 @@ EOF
             LIBS="-lva-drm -lva-x11 -lva"
         fi
         cd ../nv-codec-headers-n$NVCODEC_VERSION
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        CC="gcc -m32 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-linux
+        make -j $MAKEJ
+        make install
+
         make install PREFIX=$INSTALL_PATH
         cd ../ffmpeg-$FFMPEG_VERSION
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m32 -D__ILP32__" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -lpthread -ldl -lz -lm $LIBS"
@@ -890,7 +884,7 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        CC="gcc -m64 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared
+        CC="gcc -m64 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared
         make -j $MAKEJ
         make install
 
@@ -1407,9 +1401,9 @@ EOF
         cd ../kvazaar-$KVAZAAR_VERSION
         sed -i s/elf64ppc/elf64lppc/ configure
         if [[ "$MACHINE_TYPE" =~ ppc64 ]]; then
-          CC="gcc -m64" ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared
+          CC="gcc -m64" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared
         else
-          CC="powerpc64le-linux-gnu-gcc -m64" ./configure --host=powerpc64le-linux-gnu --build=ppc64le-linux --prefix=$INSTALL_PATH --enable-static --enable-pic  --disable-shared 
+          CC="powerpc64le-linux-gnu-gcc -m64" ./configure --host=powerpc64le-linux-gnu --build=ppc64le-linux --prefix=$INSTALL_PATH --enable-static --with-pic  --disable-shared 
         fi
         make -j $MAKEJ
         make install
@@ -1649,7 +1643,7 @@ EOF
         make install
                 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic
         make -j $MAKEJ
         make install
 
@@ -1770,6 +1764,12 @@ EOF
         make -j $MAKEJ
         make install
         cd ../nv-codec-headers-n$NVCODEC_VERSION
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32
+        make -j $MAKEJ
+        make install
+
         make install PREFIX=$INSTALL_PATH
         cd ../ffmpeg-$FFMPEG_VERSION
         PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m32" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid"
@@ -1888,6 +1888,12 @@ EOF
         make install
         cd ../nv-codec-headers-n$NVCODEC_VERSION
         make install PREFIX=$INSTALL_PATH
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32
+        make -j $MAKEJ
+        make install
+
         cd ../ffmpeg-$FFMPEG_VERSION
         PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid"
         make -j $MAKEJ

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -43,7 +43,6 @@ XML2=libxml2-2.9.12
 LIBSRT_VERSION=1.5.0
 WEBP_VERSION=1.2.4
 KVAZAAR_VERSION=a4005046ae2ebb3c88e92ff06736ce57b60fdcc7
-# https://codeload.github.com/ultravideo/kvazaar/zip/a4005046ae2ebb3c88e92ff06736ce57b60fdcc7
 FFMPEG_VERSION=5.1.2
 download https://download.videolan.org/contrib/nasm/nasm-$NASM_VERSION.tar.gz nasm-$NASM_VERSION.tar.gz
 download http://zlib.net/$ZLIB.tar.gz $ZLIB.tar.gz
@@ -1934,7 +1933,7 @@ EOF
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid -lkvazaar"
+        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid"
         make -j $MAKEJ
         make install
         ;;

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -243,13 +243,13 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=arm-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=arm-linux || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
-        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=arm --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
+        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=arm --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -381,13 +381,13 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-linux || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
-        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=aarch64 --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
+        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=aarch64 --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -516,13 +516,13 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=i686-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=i686-linux || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
-        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
+        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -650,13 +650,13 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=x86_64-linux
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=x86_64-linux || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
-        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
+        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -783,12 +783,12 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        CC="gcc -m32 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-linux
+        CC="gcc -m32 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-linux || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m32 -D__ILP32__" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -lpthread -ldl -lz -lm $LIBS"
+        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m32 -D__ILP32__" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -lpthread -ldl -lz -lm $LIBS" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -915,12 +915,12 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        CC="gcc -m64 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared
+        CC="gcc -m64 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -lpthread -ldl -lz -lm $LIBS"
+        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -lpthread -ldl -lz -lm $LIBS" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -1097,7 +1097,7 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        CC="arm-linux-gnueabihf-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=arm-linux-gnueabihf
+        CC="arm-linux-gnueabihf-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=arm-linux-gnueabihf || cat config.log
         make -j $MAKEJ
         make install
 
@@ -1107,9 +1107,9 @@ EOF
           if [[ ! -d $USERLAND_PATH ]]; then
             USERLAND_PATH="$(which arm-linux-gnueabihf-gcc | grep -o '.*/tools/')../userland"
           fi
-          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-omx --enable-mmal --enable-omx-rpi --enable-pthreads --cc="arm-linux-gnueabihf-gcc" --extra-cflags="$CFLAGS -I$USERLAND_PATH/ -I$USERLAND_PATH/interface/vmcs_host/khronos/IL/ -I$USERLAND_PATH/host_applications/linux/libs/bcm_host/include/ -I../include/ -I../include/libxml2/" --extra-ldflags="-L$USERLAND_PATH/build/lib/ -L../lib/" --extra-libs="-lstdc++ -lasound -lvchiq_arm -lvcsm -lvcos -lpthread -ldl -lz -lm" --enable-cross-compile --arch=armhf --target-os=linux --cross-prefix="arm-linux-gnueabihf-"
+          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-omx --enable-mmal --enable-omx-rpi --enable-pthreads --cc="arm-linux-gnueabihf-gcc" --extra-cflags="$CFLAGS -I$USERLAND_PATH/ -I$USERLAND_PATH/interface/vmcs_host/khronos/IL/ -I$USERLAND_PATH/host_applications/linux/libs/bcm_host/include/ -I../include/ -I../include/libxml2/" --extra-ldflags="-L$USERLAND_PATH/build/lib/ -L../lib/" --extra-libs="-lstdc++ -lasound -lvchiq_arm -lvcsm -lvcos -lpthread -ldl -lz -lm" --enable-cross-compile --arch=armhf --target-os=linux --cross-prefix="arm-linux-gnueabihf-" || cat ffbuild/config.log
         else
-          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-omx --enable-mmal --enable-omx-rpi --enable-pthreads --extra-cflags="-I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/ -L/opt/vc/lib" --extra-libs="-lstdc++ -lasound -lvchiq_arm -lvcsm -lvcos -lpthread -ldl -lz -lm"
+          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-omx --enable-mmal --enable-omx-rpi --enable-pthreads --extra-cflags="-I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/ -L/opt/vc/lib" --extra-libs="-lstdc++ -lasound -lvchiq_arm -lvcsm -lvcos -lpthread -ldl -lz -lm" || cat ffbuild/config.log
         fi
         make -j $MAKEJ
         make install
@@ -1237,7 +1237,7 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        CC="aarch64-linux-gnu-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=aarch64-linux-gnu
+        CC="aarch64-linux-gnu-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=aarch64-linux-gnu || cat config.log
         make -j $MAKEJ
         make install
 
@@ -1245,7 +1245,7 @@ EOF
         if [[ ! -d $USERLAND_PATH ]]; then
           USERLAND_PATH="$(which aarch64-linux-gnu-gcc | grep -o '.*/tools/')../userland"
         fi
-        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-omx `#--enable-mmal` --enable-omx-rpi --enable-pthreads --cc="aarch64-linux-gnu-gcc" --extra-cflags="$CFLAGS -I$USERLAND_PATH/ -I$USERLAND_PATH/interface/vmcs_host/khronos/IL/ -I$USERLAND_PATH/host_applications/linux/libs/bcm_host/include/ -I../include/ -I../include/libxml2/ -fno-aggressive-loop-optimizations" --extra-ldflags="-Wl,-z,relro -L$USERLAND_PATH/build/lib/ -L../lib/" --extra-libs="-lstdc++ -lasound -lvchiq_arm `#-lvcsm` -lvcos -lpthread -ldl -lz -lm" --enable-cross-compile --arch=arm64 --target-os=linux --cross-prefix="aarch64-linux-gnu-"
+        LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-omx `#--enable-mmal` --enable-omx-rpi --enable-pthreads --cc="aarch64-linux-gnu-gcc" --extra-cflags="$CFLAGS -I$USERLAND_PATH/ -I$USERLAND_PATH/interface/vmcs_host/khronos/IL/ -I$USERLAND_PATH/host_applications/linux/libs/bcm_host/include/ -I../include/ -I../include/libxml2/ -fno-aggressive-loop-optimizations" --extra-ldflags="-Wl,-z,relro -L$USERLAND_PATH/build/lib/ -L../lib/" --extra-libs="-lstdc++ -lasound -lvchiq_arm `#-lvcsm` -lvcos -lpthread -ldl -lz -lm" --enable-cross-compile --arch=arm64 --target-os=linux --cross-prefix="aarch64-linux-gnu-" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -1435,19 +1435,19 @@ EOF
         ./autogen.sh
         sed -i s/elf64ppc/elf64lppc/ configure
         if [[ "$MACHINE_TYPE" =~ ppc64 ]]; then
-          CC="gcc -m64" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared
+          CC="gcc -m64" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared || cat config.log
         else
-          CC="powerpc64le-linux-gnu-gcc -m64" ./configure --host=powerpc64le-linux-gnu --build=ppc64le-linux --prefix=$INSTALL_PATH --enable-static --with-pic  --disable-shared 
+          CC="powerpc64le-linux-gnu-gcc -m64" ./configure --host=powerpc64le-linux-gnu --build=ppc64le-linux --prefix=$INSTALL_PATH --enable-static --with-pic  --disable-shared  || cat config.log
         fi
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
         if [[ "$MACHINE_TYPE" =~ ppc64 ]]; then
-          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -ldl -lz -lm" --disable-altivec
+          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -ldl -lz -lm" --disable-altivec || cat ffbuild/config.log
         else
           echo "configure ffmpeg cross compile"
-          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/:/usr/lib/powerpc64le-linux-gnu/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="powerpc64le-linux-gnu-gcc -m64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --enable-cross-compile --target-os=linux --arch=ppc64le-linux --extra-libs="-lstdc++ -lpthread -ldl -lz -lm" --disable-altivec
+          LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/:/usr/lib/powerpc64le-linux-gnu/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="powerpc64le-linux-gnu-gcc -m64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --enable-cross-compile --target-os=linux --arch=ppc64le-linux --extra-libs="-lstdc++ -lpthread -ldl -lz -lm" --disable-altivec || cat ffbuild/config.log
         fi
         make -j $MAKEJ
         make install
@@ -1562,13 +1562,13 @@ EOF
         
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-apple-darwin
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-apple-darwin || cat config.log
         make -j $MAKEJ
         make install
         
         cd ../ffmpeg-$FFMPEG_VERSION
         patch -Np1 < ../../../ffmpeg-macosx.patch
-        LDEXEFLAGS='-Wl,-rpath,@loader_path/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-pthreads --enable-indev=avfoundation --disable-libxcb --cc="clang -arch arm64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -ldl -lz -lm" --enable-cross-compile --arch=arm64 --target-os=darwin
+        LDEXEFLAGS='-Wl,-rpath,@loader_path/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-pthreads --enable-indev=avfoundation --disable-libxcb --cc="clang -arch arm64" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -ldl -lz -lm" --enable-cross-compile --arch=arm64 --target-os=darwin || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -1679,13 +1679,13 @@ EOF
                 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic
+        ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
         patch -Np1 < ../../../ffmpeg-macosx.patch
-        LDEXEFLAGS='-Wl,-rpath,@loader_path/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-pthreads --enable-indev=avfoundation --disable-libxcb --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -ldl -lz -lm"
+        LDEXEFLAGS='-Wl,-rpath,@loader_path/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-pthreads --enable-indev=avfoundation --disable-libxcb --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -ldl -lz -lm" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -1804,12 +1804,12 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32
+        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m32" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid"
+        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m32" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -1928,12 +1928,12 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32
+        ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid"
+        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -1809,7 +1809,7 @@ EOF
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m32" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid" || cat ffbuild/config.log
+        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m32" --extra-cflags="-DLIBXML_STATIC -DKVZ_STATIC_LIB -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;
@@ -1933,7 +1933,7 @@ EOF
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid" || cat ffbuild/config.log
+        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -DKVZ_STATIC_LIB -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid" || cat ffbuild/config.log
         make -j $MAKEJ
         make install
         ;;

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -63,7 +63,7 @@ download http://xmlsoft.org/sources/$XML2.tar.gz $XML2.tar.gz
 download https://github.com/Haivision/srt/archive/refs/tags/v$LIBSRT_VERSION.tar.gz srt-$LIBSRT_VERSION.tar.gz
 download https://github.com/FFmpeg/nv-codec-headers/archive/n$NVCODEC_VERSION.tar.gz nv-codec-headers-$NVCODEC_VERSION.tar.gz
 download https://github.com/webmproject/libwebp/archive/refs/tags/v$WEBP_VERSION.tar.gz libwebp-$WEBP_VERSION.tar.gz
-download https://github.com/ultravideo/kvazaar/releases/download/v$KVAZAAR_VERSION/kvazaar-$KVAZAAR_VERSION.tar.gz kvazaar-$KVAZAAR_VERSION.tar.gz
+download https://github.com/ultravideo/kvazaar/archive/refs/tags/v$KVAZAAR_VERSION.tar.gz kvazaar-$KVAZAAR_VERSION.tar.gz
 download http://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.bz2 ffmpeg-$FFMPEG_VERSION.tar.bz2
 
 mkdir -p $PLATFORM$EXTENSION

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -750,13 +750,13 @@ EOF
             LIBS="-lva-drm -lva-x11 -lva"
         fi
         cd ../nv-codec-headers-n$NVCODEC_VERSION
+        make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
         CC="gcc -m32 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-linux
         make -j $MAKEJ
         make install
 
-        make install PREFIX=$INSTALL_PATH
         cd ../ffmpeg-$FFMPEG_VERSION
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-pthreads --enable-libxcb --cc="gcc -m32 -D__ILP32__" --extra-cflags="-I../include/ -I../include/libxml2" --extra-ldflags="-L../lib/" --extra-libs="-lstdc++ -lpthread -ldl -lz -lm $LIBS"
         make -j $MAKEJ
@@ -1764,13 +1764,13 @@ EOF
         make -j $MAKEJ
         make install
         cd ../nv-codec-headers-n$NVCODEC_VERSION
+        make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32
         make -j $MAKEJ
         make install
 
-        make install PREFIX=$INSTALL_PATH
         cd ../ffmpeg-$FFMPEG_VERSION
         PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m32" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid"
         make -j $MAKEJ
@@ -1895,7 +1895,7 @@ EOF
         make install
 
         cd ../ffmpeg-$FFMPEG_VERSION
-        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid"
+        PKG_CONFIG_PATH=../lib/pkgconfig/ ./configure --prefix=.. $DISABLE $ENABLE --enable-cuda --enable-cuvid --enable-nvenc --enable-libmfx --enable-w32threads --enable-indev=dshow --target-os=mingw32 --cc="gcc -m64" --extra-cflags="-DLIBXML_STATIC -I../include/ -I../include/libxml2/" --extra-ldflags="-L../lib/" --extra-libs="-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lgcc_eh -lWs2_32 -lcrypt32 -lpthread -lz -lm -Wl,-Bdynamic -lole32 -luuid -lkvazaar"
         make -j $MAKEJ
         make install
         ;;

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -1804,7 +1804,7 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        CC="clang -D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32 || cat config.log
+        CC="gcc -m32" CFLAGS="-D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install
 
@@ -1928,7 +1928,7 @@ EOF
 
         cd ../kvazaar-$KVAZAAR_VERSION
         ./autogen.sh
-        CC="clang -D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32 || cat config.log
+        CC="gcc -m64" CFLAGS="-D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install
 

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -42,7 +42,7 @@ NVCODEC_VERSION=11.1.5.1
 XML2=libxml2-2.9.12
 LIBSRT_VERSION=1.5.0
 WEBP_VERSION=1.2.4
-KVAZAAR_VERSION=a4005046ae2ebb3c88e92ff06736ce57b60fdcc7
+KVAZAAR_VERSION=2.2.0
 FFMPEG_VERSION=5.1.2
 download https://download.videolan.org/contrib/nasm/nasm-$NASM_VERSION.tar.gz nasm-$NASM_VERSION.tar.gz
 download http://zlib.net/$ZLIB.tar.gz $ZLIB.tar.gz
@@ -63,7 +63,7 @@ download http://xmlsoft.org/sources/$XML2.tar.gz $XML2.tar.gz
 download https://github.com/Haivision/srt/archive/refs/tags/v$LIBSRT_VERSION.tar.gz srt-$LIBSRT_VERSION.tar.gz
 download https://github.com/FFmpeg/nv-codec-headers/archive/n$NVCODEC_VERSION.tar.gz nv-codec-headers-$NVCODEC_VERSION.tar.gz
 download https://github.com/webmproject/libwebp/archive/refs/tags/v$WEBP_VERSION.tar.gz libwebp-$WEBP_VERSION.tar.gz
-download https://codeload.github.com/ultravideo/kvazaar/zip/a4005046ae2ebb3c88e92ff06736ce57b60fdcc7 kvazaar-$KVAZAAR_VERSION.zip
+download https://github.com/ultravideo/kvazaar/releases/download/v$KVAZAAR_VERSION/kvazaar-$KVAZAAR_VERSION.tar.gz kvazaar-$KVAZAAR_VERSION.tar.gz
 download http://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.bz2 ffmpeg-$FFMPEG_VERSION.tar.bz2
 
 mkdir -p $PLATFORM$EXTENSION
@@ -88,7 +88,7 @@ tar --totals -xzf ../mfx_dispatch-$MFX_VERSION.tar.gz
 tar --totals -xzf ../nv-codec-headers-$NVCODEC_VERSION.tar.gz
 tar --totals -xzf ../$XML2.tar.gz
 tar --totals -xzf ../libwebp-$WEBP_VERSION.tar.gz
-unzip -qo ../kvazaar-$KVAZAAR_VERSION.zip
+tar --totals -xzf ../kvazaar-$KVAZAAR_VERSION.tar.gz
 tar --totals -xjf ../ffmpeg-$FFMPEG_VERSION.tar.bz2
 
 if [[ "${ACLOCAL_PATH:-}" == C:\\msys64\\* ]]; then
@@ -242,7 +242,6 @@ EOF
         make install
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=arm-linux || cat config.log
         make -j $MAKEJ
         make install
@@ -380,7 +379,6 @@ EOF
         make install
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-linux || cat config.log
         make -j $MAKEJ
         make install
@@ -515,7 +513,6 @@ EOF
         make install
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=i686-linux || cat config.log
         make -j $MAKEJ
         make install
@@ -649,7 +646,6 @@ EOF
         make install
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=x86_64-linux || cat config.log
         make -j $MAKEJ
         make install
@@ -782,7 +778,6 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         CC="gcc -m32 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-linux || cat config.log
         make -j $MAKEJ
         make install
@@ -914,7 +909,6 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         CC="gcc -m64 -fPIC" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared || cat config.log
         make -j $MAKEJ
         make install
@@ -1096,7 +1090,6 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         CC="arm-linux-gnueabihf-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=arm-linux-gnueabihf || cat config.log
         make -j $MAKEJ
         make install
@@ -1236,7 +1229,6 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         CC="aarch64-linux-gnu-gcc" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=aarch64-linux-gnu || cat config.log
         make -j $MAKEJ
         make install
@@ -1432,7 +1424,6 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         sed -i s/elf64ppc/elf64lppc/ configure
         if [[ "$MACHINE_TYPE" =~ ppc64 ]]; then
           CC="gcc -m64" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared || cat config.log
@@ -1561,7 +1552,6 @@ EOF
         make install
         
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic --host=aarch64-apple-darwin || cat config.log
         make -j $MAKEJ
         make install
@@ -1678,7 +1668,6 @@ EOF
         make install
                 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         ./configure --prefix=$INSTALL_PATH --enable-static --disable-shared --with-pic || cat config.log
         make -j $MAKEJ
         make install
@@ -1803,7 +1792,6 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         CC="gcc -m32" CFLAGS="-D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=i686-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install
@@ -1927,7 +1915,6 @@ EOF
         make install PREFIX=$INSTALL_PATH
 
         cd ../kvazaar-$KVAZAAR_VERSION
-        ./autogen.sh
         CC="gcc -m64" CFLAGS="-D_WIN32" ./configure --prefix=$INSTALL_PATH --enable-static --with-pic --disable-shared --host=x86_64-w64-mingw32 || cat config.log
         make -j $MAKEJ
         make install

--- a/ffmpeg/cppbuild.sh
+++ b/ffmpeg/cppbuild.sh
@@ -370,6 +370,12 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=aarch64-linux
         make -j $MAKEJ
         make install
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared --host=aarch64-linux
+        make -j $MAKEJ
+        make install
+
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=aarch64 --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver
@@ -625,6 +631,12 @@ EOF
         ./configure --prefix=$INSTALL_PATH --with-bzip2=no --with-harfbuzz=no --with-png=no --with-brotli=no --enable-static --disable-shared --with-pic --host=x86_64-linux
         make -j $MAKEJ
         make install
+
+        cd ../kvazaar-$KVAZAAR_VERSION
+        ./configure --prefix=$INSTALL_PATH --enable-static --enable-pic --disable-shared --host=x86_64-linux
+        make -j $MAKEJ
+        make install
+
         cd ../ffmpeg-$FFMPEG_VERSION
         sedinplace 's/unsigned long int/unsigned int/g' libavdevice/v4l2.c
         LDEXEFLAGS='-Wl,-rpath,\$$ORIGIN/' ./configure --prefix=.. $DISABLE $ENABLE --enable-jni --enable-mediacodec --enable-pthreads --enable-cross-compile --cross-prefix="$ANDROID_PREFIX-" --ar="$AR" --ranlib="$RANLIB" --cc="$CC" --strip="$STRIP" --sysroot="$ANDROID_ROOT" --target-os=android --arch=atom --extra-cflags="-I../include/ -I../include/libxml2 $ANDROID_FLAGS" --extra-ldflags="-L../lib/ $ANDROID_FLAGS" --extra-libs="$ANDROID_LIBS -lz -latomic" --disable-symver

--- a/ffmpeg/ffmpeg.patch
+++ b/ffmpeg/ffmpeg.patch
@@ -1,6 +1,5 @@
-diff -ruN ffmpeg-5.1.1/configure ffmpeg-5.1.1-patch/configure
---- ffmpeg-5.1.1/configure	2022-09-01 03:58:25.000000000 +0900
-+++ ffmpeg-5.1.1-patch/configure	2022-09-07 09:45:10.985165854 +0900
+--- ffmpeg-5.1.2/configure	2022-09-01 04:58:25.000000000 +1000
++++ ffmpeg-5.1.2-patch/configure	2022-12-29 18:19:06.145172040 +1100
 @@ -6548,7 +6548,7 @@
  enabled libflite          && require libflite "flite/flite.h" flite_init $flite_extralibs
  enabled fontconfig        && enable libfontconfig
@@ -10,6 +9,15 @@ diff -ruN ffmpeg-5.1.1/configure ffmpeg-5.1.1-patch/configure
  enabled libfribidi        && require_pkg_config libfribidi fribidi fribidi.h fribidi_version_info
  enabled libglslang && { check_lib spirv_compiler glslang/Include/glslang_c_interface.h glslang_initialize_process \
                              -lglslang -lMachineIndependent -lOSDependent -lHLSL -lOGLCompiler -lGenericCodeGen \
+@@ -6565,7 +6565,7 @@
+ enabled libjxl            && require_pkg_config libjxl "libjxl >= 0.7.0" jxl/decode.h JxlDecoderVersion &&
+                              require_pkg_config libjxl_threads "libjxl_threads >= 0.7.0" jxl/thread_parallel_runner.h JxlThreadParallelRunner
+ enabled libklvanc         && require libklvanc libklvanc/vanc.h klvanc_context_create -lklvanc
+-enabled libkvazaar        && require_pkg_config libkvazaar "kvazaar >= 0.8.1" kvazaar.h kvz_api_get
++enabled libkvazaar        && check_lib libkvazaar kvazaar.h kvz_api_get -lkvazaar
+ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_db_new
+ # While it may appear that require is being used as a pkg-config
+ # fallback for libmfx, it is actually being used to detect a different
 @@ -6573,11 +6573,7 @@
  # Media SDK or Intel Media Server Studio, these don't come with
  # pkg-config support.  Instead, users should make sure that the build

--- a/ffmpeg/ffmpeg.patch
+++ b/ffmpeg/ffmpeg.patch
@@ -14,7 +14,7 @@
                               require_pkg_config libjxl_threads "libjxl_threads >= 0.7.0" jxl/thread_parallel_runner.h JxlThreadParallelRunner
  enabled libklvanc         && require libklvanc libklvanc/vanc.h klvanc_context_create -lklvanc
 -enabled libkvazaar        && require_pkg_config libkvazaar "kvazaar >= 0.8.1" kvazaar.h kvz_api_get
-+enabled libkvazaar        && check_lib libkvazaar kvazaar.h kvz_api_get -lkvazaar
++enabled libkvazaar        && require libkvazaar kvazaar.h kvz_api_get -lkvazaar
  enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_db_new
  # While it may appear that require is being used as a pkg-config
  # fallback for libmfx, it is actually being used to detect a different

--- a/ffmpeg/kvazaar.patch
+++ b/ffmpeg/kvazaar.patch
@@ -1,0 +1,18 @@
+--- kvazaar-a4005046ae2ebb3c88e92ff06736ce57b60fdcc7/configure.ac	2022-10-12 20:19:40.000000000 +1100
++++ kvazaar-a4005046ae2ebb3c88e92ff06736ce57b60fdcc7-patch/configure.ac	2022-12-31 13:27:15.482424499 +1100
+@@ -79,6 +79,7 @@
+ AC_SEARCH_LIBS([log], [m c], [], [exit 1])
+ AC_SEARCH_LIBS([pow], [m c], [], [exit 1])
+ AC_SEARCH_LIBS([sqrt], [m c], [], [exit 1])
++AC_SEARCH_LIBS([sem_init], [rt c], [], [exit 1])
+ 
+ AC_ARG_WITH([cryptopp],
+     AS_HELP_STRING([--with-cryptopp],
+@@ -157,7 +158,6 @@
+         [linux*|*kfreebsd*], [
+          ASFLAGS="$ASFLAGS -f elf$BITS"
+          LDFLAGS="$LDFLAGS -Wl,-z,noexecstack"
+-         LIBS="$LIBS -lrt"
+         ], [
+          ASFLAGS="$ASFLAGS -f elf$BITS"
+          LDFLAGS="$LDFLAGS -Wl,-z,noexecstack"

--- a/ffmpeg/kvazaar.patch
+++ b/ffmpeg/kvazaar.patch
@@ -4,7 +4,7 @@
  AC_SEARCH_LIBS([log], [m c], [], [exit 1])
  AC_SEARCH_LIBS([pow], [m c], [], [exit 1])
  AC_SEARCH_LIBS([sqrt], [m c], [], [exit 1])
-+AC_SEARCH_LIBS([sem_init], [rt c], [], [exit 1])
++AC_SEARCH_LIBS([sem_init], [pthread rt posix4], [], [exit 1])
  
  AC_ARG_WITH([cryptopp],
      AS_HELP_STRING([--with-cryptopp],

--- a/ffmpeg/kvazaar.patch
+++ b/ffmpeg/kvazaar.patch
@@ -1,5 +1,87 @@
---- kvazaar-a4005046ae2ebb3c88e92ff06736ce57b60fdcc7/configure.ac	2022-10-12 20:19:40.000000000 +1100
-+++ kvazaar-a4005046ae2ebb3c88e92ff06736ce57b60fdcc7-patch/configure.ac	2022-12-31 13:27:15.482424499 +1100
+Only in kvazaar-2.2.0-patch: autom4te.cache
+diff -aur kvazaar-2.2.0/configure kvazaar-2.2.0-patch/configure
+--- kvazaar-2.2.0/configure	2023-01-04 20:47:30.000000000 +1100
++++ kvazaar-2.2.0-patch/configure	2023-01-06 12:51:27.863126084 +1100
+@@ -18088,6 +18088,67 @@
+   exit 1
+ fi
+ 
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing sem_init" >&5
++printf %s "checking for library containing sem_init... " >&6; }
++if test ${ac_cv_search_sem_init+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  ac_func_search_save_LIBS=$LIBS
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++char sem_init ();
++int
++main (void)
++{
++return sem_init ();
++  ;
++  return 0;
++}
++_ACEOF
++for ac_lib in '' pthread rt posix4
++do
++  if test -z "$ac_lib"; then
++    ac_res="none required"
++  else
++    ac_res=-l$ac_lib
++    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
++  fi
++  if ac_fn_c_try_link "$LINENO"
++then :
++  ac_cv_search_sem_init=$ac_res
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext
++  if test ${ac_cv_search_sem_init+y}
++then :
++  break
++fi
++done
++if test ${ac_cv_search_sem_init+y}
++then :
++
++else $as_nop
++  ac_cv_search_sem_init=no
++fi
++rm conftest.$ac_ext
++LIBS=$ac_func_search_save_LIBS
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_sem_init" >&5
++printf "%s\n" "$ac_cv_search_sem_init" >&6; }
++ac_res=$ac_cv_search_sem_init
++if test "$ac_res" != no
++then :
++  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
++
++else $as_nop
++  exit 1
++fi
++
+ 
+ 
+ # Check whether --with-cryptopp was given.
+@@ -19641,7 +19702,6 @@
+ 
+          ASFLAGS="$ASFLAGS -f elf$BITS"
+          LDFLAGS="$LDFLAGS -Wl,-z,noexecstack"
+-         LIBS="$LIBS -lrt"
+          ;; #(
+   *) :
+ 
+Only in kvazaar-2.2.0-patch: configure~
+diff -aur kvazaar-2.2.0/configure.ac kvazaar-2.2.0-patch/configure.ac
+--- kvazaar-2.2.0/configure.ac	2023-01-04 20:40:58.000000000 +1100
++++ kvazaar-2.2.0-patch/configure.ac	2023-01-06 12:43:27.493134043 +1100
 @@ -79,6 +79,7 @@
  AC_SEARCH_LIBS([log], [m c], [], [exit 1])
  AC_SEARCH_LIBS([pow], [m c], [], [exit 1])
@@ -16,3 +98,16 @@
          ], [
           ASFLAGS="$ASFLAGS -f elf$BITS"
           LDFLAGS="$LDFLAGS -Wl,-z,noexecstack"
+diff -aur kvazaar-2.2.0/Makefile.in kvazaar-2.2.0-patch/Makefile.in
+--- kvazaar-2.2.0/Makefile.in	2023-01-04 20:47:30.000000000 +1100
++++ kvazaar-2.2.0-patch/Makefile.in	2023-01-06 12:51:28.115125299 +1100
+@@ -200,7 +200,8 @@
+ 	$(top_srcdir)/build-aux/ltmain.sh \
+ 	$(top_srcdir)/build-aux/missing README.md build-aux/ar-lib \
+ 	build-aux/compile build-aux/config.guess build-aux/config.sub \
+-	build-aux/install-sh build-aux/ltmain.sh build-aux/missing
++	build-aux/depcomp build-aux/install-sh build-aux/ltmain.sh \
++	build-aux/missing
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ distdir = $(PACKAGE)-$(VERSION)
+ top_distdir = $(distdir)


### PR DESCRIPTION
AFAICT, there is no support for building on Android, nor ARM.

The windows build is working for the libkvazaar dependency, but it looks like that dependency isn't getting picked up by ffmpeg configure script.