### PR TITLE
Bundle libcupti with libtorch to make it work with cuda-platform-redist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Bundle the CUPTI module of CUDA in the presets for PyTorch ([pull #1307](https://github.com/bytedeco/javacpp-presets/pull/1307))
  * Build FFmpeg with AOMedia AV1 and SVT-AV1 codecs ([pull #1303](https://github.com/bytedeco/javacpp-presets/pull/1303))
  * Map `c10::OptionalArrayRef<int64_t>` from PyTorch to `long...` as well for convenience ([issue #1300](https://github.com/bytedeco/javacpp-presets/issues/1300))
  * Remove mapping for `c10::OptionalArrayRef` to simplify calls in presets for PyTorch ([issue #1300](https://github.com/bytedeco/javacpp-presets/issues/1300))

--- a/pytorch/src/main/java/org/bytedeco/pytorch/presets/torch.java
+++ b/pytorch/src/main/java/org/bytedeco/pytorch/presets/torch.java
@@ -1735,17 +1735,18 @@ import org.bytedeco.openblas.presets.openblas;
         ),
         @Platform(
             value = {"linux", "macosx", "windows"},
-            linkpath = {
-                    "/usr/local/cuda-11.8/lib64/",
-                    "/usr/local/cuda-11.8/extras/CUPTI/lib64/",
-                    "/usr/local/cuda/lib64/",
-                    "/usr/local/cuda/extras/CUPTI/lib64/",
-                    "/usr/lib64/",
-                    "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.8/lib/x64/",
-                    "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.8/extras/CUPTI/lib64/"
+            link = {"c10", "c10_cuda", "torch_cpu", "torch_cuda", "torch"},
+            preload = {"gomp@.1", "iomp5", "omp", "tbb@.2", "asmjit", "fbgemm", "cupti@.11.8"},
+            preloadpath = {
+                "/usr/local/cuda-11.8/lib64/",
+                "/usr/local/cuda-11.8/extras/CUPTI/lib64/",
+                "/usr/local/cuda/lib64/",
+                "/usr/local/cuda/extras/CUPTI/lib64/",
+                "/usr/lib64/",
+                "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.8/lib/x64/",
+                "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.8/extras/CUPTI/lib64/",
+                "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/x64/",
             },
-            link = {"c10", "c10_cuda", "torch_cpu", "torch_cuda", "torch", "cupti@.11.8"},
-            preloadpath = "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/x64/",
             extension = "-gpu"
         ),
     },

--- a/pytorch/src/main/java/org/bytedeco/pytorch/presets/torch.java
+++ b/pytorch/src/main/java/org/bytedeco/pytorch/presets/torch.java
@@ -1735,7 +1735,16 @@ import org.bytedeco.openblas.presets.openblas;
         ),
         @Platform(
             value = {"linux", "macosx", "windows"},
-            link = {"c10", "c10_cuda", "torch_cpu", "torch_cuda", "torch"},
+            linkpath = {
+                    "/usr/local/cuda-11.8/lib64/",
+                    "/usr/local/cuda-11.8/extras/CUPTI/lib64/",
+                    "/usr/local/cuda/lib64/",
+                    "/usr/local/cuda/extras/CUPTI/lib64/",
+                    "/usr/lib64/",
+                    "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.8/lib/x64/",
+                    "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.8/extras/CUPTI/lib64/"
+            },
+            link = {"c10", "c10_cuda", "torch_cpu", "torch_cuda", "torch", "cupti@.11.8"},
             preloadpath = "C:/Program Files/NVIDIA Corporation/NvToolsExt/bin/x64/",
             extension = "-gpu"
         ),


### PR DESCRIPTION
I've managed to bundle libcupti by adding it to the link list. Is this the right approach in general?

One issue is that it adds `libcupti.so` without the version information, but `libcuda` links with `libcupti.so.11.8`.