### PR TITLE
Prevent the buffer overflow error in ClangTokenizeExample

### DIFF
--- a/llvm/samples/clang/ClangTokenizeExample.java
+++ b/llvm/samples/clang/ClangTokenizeExample.java
@@ -56,6 +56,8 @@ public class ClangTokenizeExample {
 		// dispose all allocated data
 		clang.clang_disposeTranslationUnit(translationUnit);
 		clang.clang_disposeIndex(index);
+		// re-set the pointer we've incremented previosly (see `show_all_tokens()`)
+		tokens.position(0L);
 		clang.clang_disposeTokens(translationUnit, tokens, numTokens[0]);
 	}
 

--- a/llvm/samples/clang/ClangTokenizeExample.java
+++ b/llvm/samples/clang/ClangTokenizeExample.java
@@ -56,7 +56,7 @@ public class ClangTokenizeExample {
 		// dispose all allocated data
 		clang.clang_disposeTranslationUnit(translationUnit);
 		clang.clang_disposeIndex(index);
-		// re-set the pointer we've incremented previosly (see `show_all_tokens()`)
+		// re-set the pointer we've incremented previously (see `show_all_tokens()`)
 		tokens.position(0L);
 		clang.clang_disposeTokens(translationUnit, tokens, numTokens[0]);
 	}


### PR DESCRIPTION
Before calling `clang.clang_disposeTokens()`, the previously incremented pointer should be re-set to point back to the beginning of the buffer.