### PR TITLE
[PyTorch] Update to 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  * Refactor and improve presets for PyTorch ([pull #1360](https://github.com/bytedeco/javacpp-presets/pull/1360))
  * Include `mkl_lapack.h` header file in presets for MKL ([issue #1388](https://github.com/bytedeco/javacpp-presets/issues/1388))
  * Map new higher-level C++ API of Triton Inference Server ([pull #1361](https://github.com/bytedeco/javacpp-presets/pull/1361))
- * Upgrade presets for OpenCV 4.8.1, FFmpeg 6.1, HDF5 1.14.3, DNNL 3.3.2, OpenBLAS 0.3.25, ARPACK-NG 3.9.1, CPython 3.12.0, NumPy 1.26.2, SciPy 1.11.4, LLVM 17.0.6, Leptonica 1.83.1, Tesseract 5.3.3, CUDA 12.3.0, cuDNN 8.9.5, NCCL 2.18.5, PyTorch 2.1.1 ([pull #1426](https://github.com/bytedeco/javacpp-presets/pull/1426)), TensorFlow Lite 2.15.0, Triton Inference Server 2.38.0, DepthAI 2.23.0, ONNX 1.15.0, ONNX Runtime 1.16.3, TVM 0.14.0, and their dependencies
+ * Upgrade presets for OpenCV 4.8.1, FFmpeg 6.1, HDF5 1.14.3, DNNL 3.3.2, OpenBLAS 0.3.25, ARPACK-NG 3.9.1, CPython 3.12.0, NumPy 1.26.2, SciPy 1.11.4, LLVM 17.0.6, Leptonica 1.83.1, Tesseract 5.3.3, CUDA 12.3.0, cuDNN 8.9.5, NCCL 2.18.5, PyTorch 2.1.2 ([pull #1426](https://github.com/bytedeco/javacpp-presets/pull/1426)), TensorFlow Lite 2.15.0, Triton Inference Server 2.38.0, DepthAI 2.23.0, ONNX 1.15.0, ONNX Runtime 1.16.3, TVM 0.14.0, and their dependencies
 
 ### June 6, 2023 version 1.5.9
  * Virtualize `nvinfer1::IGpuAllocator` from TensorRT to allow customization ([pull #1367](https://github.com/bytedeco/javacpp-presets/pull/1367))

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -292,7 +292,7 @@
     <dependency>
       <groupId>org.bytedeco</groupId>
       <artifactId>pytorch-platform</artifactId>
-      <version>2.1.1-${project.version}</version>
+      <version>2.1.2-${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bytedeco</groupId>

--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -9,7 +9,7 @@ Introduction
 ------------
 This directory contains the JavaCPP Presets module for:
 
- * PyTorch 2.1.1  https://pytorch.org/
+ * PyTorch 2.1.2  https://pytorch.org/
 
 Please refer to the parent README.md file for more detailed information about the JavaCPP Presets.
 
@@ -48,14 +48,14 @@ We can use [Maven 3](http://maven.apache.org/) to download and install automatic
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>pytorch-platform</artifactId>
-            <version>2.1.1-1.5.10-SNAPSHOT</version>
+            <version>2.1.2-1.5.10-SNAPSHOT</version>
         </dependency>
 
         <!-- Additional dependencies required to use CUDA, cuDNN, and NCCL -->
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>pytorch-platform-gpu</artifactId>
-            <version>2.1.1-1.5.10-SNAPSHOT</version>
+            <version>2.1.2-1.5.10-SNAPSHOT</version>
         </dependency>
 
         <!-- Additional dependencies to use bundled CUDA, cuDNN, and NCCL -->

--- a/pytorch/cppbuild.sh
+++ b/pytorch/cppbuild.sh
@@ -35,7 +35,7 @@ if [[ $PLATFORM == windows* ]]; then
     export PYTHON_BIN_PATH=$(which python.exe)
 fi
 
-PYTORCH_VERSION=2.1.1
+PYTORCH_VERSION=2.1.2
 
 export PYTORCH_BUILD_VERSION="$PYTORCH_VERSION"
 export PYTORCH_BUILD_NUMBER=1

--- a/pytorch/platform/gpu/pom.xml
+++ b/pytorch/platform/gpu/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.bytedeco</groupId>
   <artifactId>pytorch-platform-gpu</artifactId>
-  <version>2.1.1-${project.parent.version}</version>
+  <version>2.1.2-${project.parent.version}</version>
   <name>JavaCPP Presets Platform GPU for PyTorch</name>
 
   <properties>

--- a/pytorch/platform/pom.xml
+++ b/pytorch/platform/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.bytedeco</groupId>
   <artifactId>pytorch-platform</artifactId>
-  <version>2.1.1-${project.parent.version}</version>
+  <version>2.1.2-${project.parent.version}</version>
   <name>JavaCPP Presets Platform for PyTorch</name>
 
   <properties>

--- a/pytorch/pom.xml
+++ b/pytorch/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.bytedeco</groupId>
   <artifactId>pytorch</artifactId>
-  <version>2.1.1-${project.parent.version}</version>
+  <version>2.1.2-${project.parent.version}</version>
   <name>JavaCPP Presets for PyTorch</name>
 
   <dependencies>

--- a/pytorch/samples/pom.xml
+++ b/pytorch/samples/pom.xml
@@ -12,14 +12,14 @@
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>pytorch-platform</artifactId>
-            <version>2.1.1-1.5.10-SNAPSHOT</version>
+            <version>2.1.2-1.5.10-SNAPSHOT</version>
         </dependency>
 
         <!-- Additional dependencies required to use CUDA, cuDNN, and NCCL -->
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>pytorch-platform-gpu</artifactId>
-            <version>2.1.1-1.5.10-SNAPSHOT</version>
+            <version>2.1.2-1.5.10-SNAPSHOT</version>
         </dependency>
 
         <!-- Additional dependencies to use bundled CUDA, cuDNN, and NCCL -->

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/cuda/DeviceStats.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/cuda/DeviceStats.java
@@ -42,25 +42,25 @@ public class DeviceStats extends Pointer {
     }
 
   // COUNT: allocations requested by client code
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer allocation(); public native DeviceStats allocation(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat allocation(); public native DeviceStats allocation(Stat setter);
   // COUNT: number of allocated segments from cudaMalloc().
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer segment(); public native DeviceStats segment(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat segment(); public native DeviceStats segment(Stat setter);
   // COUNT: number of active memory blocks (allocated or used by stream)
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer active(); public native DeviceStats active(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat active(); public native DeviceStats active(Stat setter);
   // COUNT: number of inactive, split memory blocks (unallocated but can't be
   // released via cudaFree)
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer inactive_split(); public native DeviceStats inactive_split(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat inactive_split(); public native DeviceStats inactive_split(Stat setter);
 
   // SUM: bytes allocated by this memory alocator
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer allocated_bytes(); public native DeviceStats allocated_bytes(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat allocated_bytes(); public native DeviceStats allocated_bytes(Stat setter);
   // SUM: bytes reserved by this memory allocator (both free and used)
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer reserved_bytes(); public native DeviceStats reserved_bytes(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat reserved_bytes(); public native DeviceStats reserved_bytes(Stat setter);
   // SUM: bytes within active memory blocks
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer active_bytes(); public native DeviceStats active_bytes(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat active_bytes(); public native DeviceStats active_bytes(Stat setter);
   // SUM: bytes within inactive, split memory blocks
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer inactive_split_bytes(); public native DeviceStats inactive_split_bytes(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat inactive_split_bytes(); public native DeviceStats inactive_split_bytes(Stat setter);
   // SUM: bytes requested by client code
-  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") BoolPointer requested_bytes(); public native DeviceStats requested_bytes(BoolPointer setter);
+  public native @ByRef @Cast("c10::cuda::CUDACachingAllocator::StatArray*") Stat requested_bytes(); public native DeviceStats requested_bytes(Stat setter);
 
   // COUNT: total number of failed calls to CUDA malloc necessitating cache
   // flushes.

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/global/torch.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/global/torch.java
@@ -76579,11 +76579,11 @@ public static final int TORCH_VERSION_MAJOR = 2;
 public static final int TORCH_VERSION_MINOR = 1;
 
 /** Indicates the patch version of LibTorch. */
-public static final int TORCH_VERSION_PATCH = 1;
+public static final int TORCH_VERSION_PATCH = 2;
 
 /** Indicates the version of LibTorch. */
 public static final String TORCH_VERSION = 
-  "2.1.1";
+  "2.1.2";
 
 
 // Parsed from torch/csrc/autograd/InferenceMode.h

--- a/pytorch/src/main/java/org/bytedeco/pytorch/presets/torch_cuda.java
+++ b/pytorch/src/main/java/org/bytedeco/pytorch/presets/torch_cuda.java
@@ -104,6 +104,9 @@ public class torch_cuda implements LoadEnabled, InfoMapper {
             .put(new Info("std::vector<c10::cuda::CUDAKernelLaunchInfo>").pointerTypes("CUDAKernelLaunchInfoVector").define())
             .put(new Info("const std::vector<c10::cuda::CUDACachingAllocator::TraceEntry>", "std::vector<c10::cuda::CUDACachingAllocator::TraceEntry>").pointerTypes("TraceEntryVector").define())
 
+            //// std::array
+            .put(new Info("std::array<c10::cuda::CUDACachingAllocator::Stat,3>", "c10::cuda::CUDACachingAllocator::StatArray").cast().pointerTypes("Stat"))
+
             //// Function pointers
             // Function pointer returning shared_ptr don't compile on windows
             // "D:\a\javacpp-presets\javacpp-presets\pytorch\target\native\org\bytedeco\pytorch\windows-x86_64\jnitorch.cpp(98904): error C2526: 'JavaCPP_org_bytedeco_pytorch_functions_GatheredContextSupplier_allocate_callback': C linkage function cannot return C++ class 'std::shared_ptr<c10::GatheredContext>'"


### PR DESCRIPTION
Included in this PR:
* Add missing mapping for `std::array<CUDACachingAllocator::Stat>`
* Update to PyTorch 2.1.2