### PR TITLE
Fix mapping of unique pointers

### DIFF
--- a/pytorch/src/gen/java/org/bytedeco/pytorch/AdagradOptions.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/AdagradOptions.java
@@ -25,9 +25,9 @@ public class AdagradOptions extends OptimizerCloneableAdagradOptions {
     public AdagradOptions(Pointer p) { super(p); }
 
   public AdagradOptions(double lr/*=1e-2*/) { super((Pointer)null); allocate(lr); }
-  private native void allocate(double lr/*=1e-2*/);
+  @UniquePtr @Name("std::make_unique<torch::optim::AdagradOptions>") private native void allocate(double lr/*=1e-2*/);
   public AdagradOptions() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<torch::optim::AdagradOptions>") private native void allocate();
   public native @ByRef @NoException(true) DoublePointer lr();
   public native @ByRef @NoException(true) DoublePointer lr_decay();
   public native @ByRef @NoException(true) DoublePointer weight_decay();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/AdagradParamState.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/AdagradParamState.java
@@ -23,18 +23,9 @@ public class AdagradParamState extends OptimizerCloneableAdagradParamState {
     static { Loader.load(); }
     /** Default native constructor. */
     public AdagradParamState() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public AdagradParamState(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public AdagradParamState(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public AdagradParamState position(long position) {
-        return (AdagradParamState)super.position(position);
-    }
-    @Override public AdagradParamState getPointer(long i) {
-        return new AdagradParamState((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::AdagradParamState>") private native void allocate();
 
   public native @ByRef @NoException(true) Tensor sum();
   public native @Cast("int64_t*") @ByRef @NoException(true) LongPointer step();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/AdamOptions.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/AdamOptions.java
@@ -25,9 +25,9 @@ public class AdamOptions extends OptimizerCloneableAdamOptions {
     public AdamOptions(Pointer p) { super(p); }
 
   public AdamOptions(double lr/*=1e-3*/) { super((Pointer)null); allocate(lr); }
-  private native void allocate(double lr/*=1e-3*/);
+  @UniquePtr @Name("std::make_unique<torch::optim::AdamOptions>") private native void allocate(double lr/*=1e-3*/);
   public AdamOptions() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<torch::optim::AdamOptions>") private native void allocate();
   public native @ByRef @NoException(true) DoublePointer lr();
   public native @Cast("std::tuple<double,double>*") @ByRef @NoException DoublePointer betas();
   public native @ByRef @NoException(true) DoublePointer eps();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/AdamParamState.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/AdamParamState.java
@@ -23,18 +23,9 @@ public class AdamParamState extends OptimizerCloneableAdamParamState {
     static { Loader.load(); }
     /** Default native constructor. */
     public AdamParamState() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public AdamParamState(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public AdamParamState(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public AdamParamState position(long position) {
-        return (AdamParamState)super.position(position);
-    }
-    @Override public AdamParamState getPointer(long i) {
-        return new AdamParamState((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::AdamParamState>") private native void allocate();
 
   public native @Cast("int64_t*") @ByRef @NoException(true) LongPointer step();
   public native @ByRef @NoException(true) Tensor exp_avg();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/AdamWOptions.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/AdamWOptions.java
@@ -25,9 +25,9 @@ public class AdamWOptions extends OptimizerCloneableAdamWOptions {
     public AdamWOptions(Pointer p) { super(p); }
 
   public AdamWOptions(double lr/*=1e-3*/) { super((Pointer)null); allocate(lr); }
-  private native void allocate(double lr/*=1e-3*/);
+  @UniquePtr @Name("std::make_unique<torch::optim::AdamWOptions>") private native void allocate(double lr/*=1e-3*/);
   public AdamWOptions() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<torch::optim::AdamWOptions>") private native void allocate();
   public native @ByRef @NoException(true) DoublePointer lr();
   public native @Cast("std::tuple<double,double>*") @ByRef @NoException DoublePointer betas();
   public native @ByRef @NoException(true) DoublePointer eps();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/AdamWParamState.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/AdamWParamState.java
@@ -23,18 +23,9 @@ public class AdamWParamState extends OptimizerCloneableAdamWParamState {
     static { Loader.load(); }
     /** Default native constructor. */
     public AdamWParamState() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public AdamWParamState(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public AdamWParamState(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public AdamWParamState position(long position) {
-        return (AdamWParamState)super.position(position);
-    }
-    @Override public AdamWParamState getPointer(long i) {
-        return new AdamWParamState((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::AdamWParamState>") private native void allocate();
 
   public native @Cast("int64_t*") @ByRef @NoException(true) LongPointer step();
   public native @ByRef @NoException(true) Tensor exp_avg();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/AutogradMeta.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/AutogradMeta.java
@@ -32,15 +32,6 @@ public class AutogradMeta extends AutogradMetaInterface {
     static { Loader.load(); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public AutogradMeta(Pointer p) { super(p); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public AutogradMeta(long size) { super((Pointer)null); allocateArray(size); }
-    private native void allocateArray(long size);
-    @Override public AutogradMeta position(long position) {
-        return (AutogradMeta)super.position(position);
-    }
-    @Override public AutogradMeta getPointer(long i) {
-        return new AutogradMeta((Pointer)this).offsetAddress(i);
-    }
 
   public native @StdString BytePointer name_(); public native AutogradMeta name_(BytePointer setter);
 
@@ -121,10 +112,10 @@ public class AutogradMeta extends AutogradMetaInterface {
         TensorImpl self_impl/*=nullptr*/,
         @Cast("bool") boolean requires_grad/*=false*/,
         @ByVal(nullValue = "torch::autograd::Edge()") Edge gradient_edge) { super((Pointer)null); allocate(self_impl, requires_grad, gradient_edge); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<torch::autograd::AutogradMeta>") private native void allocate(
         TensorImpl self_impl/*=nullptr*/,
         @Cast("bool") boolean requires_grad/*=false*/,
         @ByVal(nullValue = "torch::autograd::Edge()") Edge gradient_edge);
   public AutogradMeta() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<torch::autograd::AutogradMeta>") private native void allocate();
 }

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/CPUGeneratorImpl.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/CPUGeneratorImpl.java
@@ -26,9 +26,9 @@ public class CPUGeneratorImpl extends GeneratorImpl {
 
   // Constructors
   public CPUGeneratorImpl(@Cast("uint64_t") long seed_in/*=c10::default_rng_seed_val*/) { super((Pointer)null); allocate(seed_in); }
-  private native void allocate(@Cast("uint64_t") long seed_in/*=c10::default_rng_seed_val*/);
+  @UniquePtr @Name("std::make_unique<at::CPUGeneratorImpl>") private native void allocate(@Cast("uint64_t") long seed_in/*=c10::default_rng_seed_val*/);
   public CPUGeneratorImpl() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<at::CPUGeneratorImpl>") private native void allocate();
 
   // CPUGeneratorImpl methods
   public native @SharedPtr CPUGeneratorImpl clone();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/Dispatcher.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/Dispatcher.java
@@ -129,8 +129,8 @@ public class Dispatcher extends Pointer {
    */
   // NB: steals the inferred function schema, as we may need to hold on to
   // it for a bit until the real schema turns up
-  public native @ByVal RegistrationHandleRAII registerImpl(@ByVal OperatorName op_name, @ByVal DispatchKeyOptional dispatch_key, @ByVal KernelFunction kernel, @ByVal CppSignatureOptional cpp_signature, @UniquePtr @Cast({"", "std::unique_ptr<c10::FunctionSchema>&&"}) FunctionSchema inferred_function_schema, @StdString BytePointer debug);
-  public native @ByVal RegistrationHandleRAII registerImpl(@ByVal OperatorName op_name, @ByVal DispatchKeyOptional dispatch_key, @ByVal KernelFunction kernel, @ByVal CppSignatureOptional cpp_signature, @UniquePtr @Cast({"", "std::unique_ptr<c10::FunctionSchema>&&"}) FunctionSchema inferred_function_schema, @StdString String debug);
+  public native @ByVal RegistrationHandleRAII registerImpl(@ByVal OperatorName op_name, @ByVal DispatchKeyOptional dispatch_key, @ByVal KernelFunction kernel, @ByVal CppSignatureOptional cpp_signature, @UniquePtr @ByVal FunctionSchema inferred_function_schema, @StdString BytePointer debug);
+  public native @ByVal RegistrationHandleRAII registerImpl(@ByVal OperatorName op_name, @ByVal DispatchKeyOptional dispatch_key, @ByVal KernelFunction kernel, @ByVal CppSignatureOptional cpp_signature, @UniquePtr @ByVal FunctionSchema inferred_function_schema, @StdString String debug);
 
   /**
    * Register a new operator by name.

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/FunctionPostHookVector.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/FunctionPostHookVector.java
@@ -31,7 +31,7 @@ public class FunctionPostHookVector extends Pointer {
 
     public FunctionPostHook front() { return get(0); }
     public FunctionPostHook back() { return get(size() - 1); }
-    @Index(function = "at") public native @UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPostHook>&&"}) FunctionPostHook get(@Cast("size_t") long i);
+    @Index(function = "at") public native @UniquePtr FunctionPostHook get(@Cast("size_t") long i);
 
     public native @ByVal Iterator begin();
     public native @ByVal Iterator end();
@@ -41,7 +41,7 @@ public class FunctionPostHookVector extends Pointer {
 
         public native @Name("operator ++") @ByRef Iterator increment();
         public native @Name("operator ==") boolean equals(@ByRef Iterator it);
-        public native @Name("operator *") @UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPostHook>&&"}) FunctionPostHook get();
+        public native @Name("operator *") @UniquePtr @Const FunctionPostHook get();
     }
 }
 

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/FunctionPreHookVector.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/FunctionPreHookVector.java
@@ -31,7 +31,7 @@ public class FunctionPreHookVector extends Pointer {
 
     public FunctionPreHook front() { return get(0); }
     public FunctionPreHook back() { return get(size() - 1); }
-    @Index(function = "at") public native @UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPreHook>&&"}) FunctionPreHook get(@Cast("size_t") long i);
+    @Index(function = "at") public native @UniquePtr FunctionPreHook get(@Cast("size_t") long i);
 
     public native @ByVal Iterator begin();
     public native @ByVal Iterator end();
@@ -41,7 +41,7 @@ public class FunctionPreHookVector extends Pointer {
 
         public native @Name("operator ++") @ByRef Iterator increment();
         public native @Name("operator ==") boolean equals(@ByRef Iterator it);
-        public native @Name("operator *") @UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPreHook>&&"}) FunctionPreHook get();
+        public native @Name("operator *") @UniquePtr @Const FunctionPreHook get();
     }
 }
 

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/FunctionSchema.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/FunctionSchema.java
@@ -31,7 +31,7 @@ public class FunctionSchema extends Pointer {
         @StdVector Argument returns,
         @Cast("bool") boolean is_vararg/*=false*/,
         @Cast("bool") boolean is_varret/*=false*/) { super((Pointer)null); allocate(name, overload_name, arguments, returns, is_vararg, is_varret); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @StdString BytePointer name,
         @StdString BytePointer overload_name,
         @StdVector Argument arguments,
@@ -43,7 +43,7 @@ public class FunctionSchema extends Pointer {
         @StdString BytePointer overload_name,
         @StdVector Argument arguments,
         @StdVector Argument returns) { super((Pointer)null); allocate(name, overload_name, arguments, returns); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @StdString BytePointer name,
         @StdString BytePointer overload_name,
         @StdVector Argument arguments,
@@ -55,7 +55,7 @@ public class FunctionSchema extends Pointer {
         @StdVector Argument returns,
         @Cast("bool") boolean is_vararg/*=false*/,
         @Cast("bool") boolean is_varret/*=false*/) { super((Pointer)null); allocate(name, overload_name, arguments, returns, is_vararg, is_varret); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @StdString String name,
         @StdString String overload_name,
         @StdVector Argument arguments,
@@ -67,7 +67,7 @@ public class FunctionSchema extends Pointer {
         @StdString String overload_name,
         @StdVector Argument arguments,
         @StdVector Argument returns) { super((Pointer)null); allocate(name, overload_name, arguments, returns); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @StdString String name,
         @StdString String overload_name,
         @StdVector Argument arguments,
@@ -80,7 +80,7 @@ public class FunctionSchema extends Pointer {
         @StdVector Argument returns,
         @Cast("bool") boolean is_vararg/*=false*/,
         @Cast("bool") boolean is_varret/*=false*/) { super((Pointer)null); allocate(name, overload_name, arguments, returns, is_vararg, is_varret); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @ByVal Symbol name,
         @StdString BytePointer overload_name,
         @StdVector Argument arguments,
@@ -92,7 +92,7 @@ public class FunctionSchema extends Pointer {
         @StdString BytePointer overload_name,
         @StdVector Argument arguments,
         @StdVector Argument returns) { super((Pointer)null); allocate(name, overload_name, arguments, returns); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @ByVal Symbol name,
         @StdString BytePointer overload_name,
         @StdVector Argument arguments,
@@ -104,7 +104,7 @@ public class FunctionSchema extends Pointer {
         @StdVector Argument returns,
         @Cast("bool") boolean is_vararg/*=false*/,
         @Cast("bool") boolean is_varret/*=false*/) { super((Pointer)null); allocate(name, overload_name, arguments, returns, is_vararg, is_varret); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @ByVal Symbol name,
         @StdString String overload_name,
         @StdVector Argument arguments,
@@ -116,7 +116,7 @@ public class FunctionSchema extends Pointer {
         @StdString String overload_name,
         @StdVector Argument arguments,
         @StdVector Argument returns) { super((Pointer)null); allocate(name, overload_name, arguments, returns); }
-  private native void allocate(
+  @UniquePtr @Name("std::make_unique<c10::FunctionSchema>") private native void allocate(
         @ByVal Symbol name,
         @StdString String overload_name,
         @StdVector Argument arguments,

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/Graph.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/Graph.java
@@ -230,6 +230,6 @@ public class Graph extends Pointer {
   public Pointer shiftLeft(Pointer out) { return shiftLeft(out, this); }
 
   public native @SharedPtr("torch::jit::Graph") @ByVal Graph copy();
-  public native @UniquePtr Graph copyUnique();
+  public native @UniquePtr @ByVal Graph copyUnique();
   public native void remapTypes(@Const @ByRef TypeMapper type_map);
 }

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/GraphAttr.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/GraphAttr.java
@@ -27,7 +27,7 @@ public class GraphAttr extends AttributeValue {
     public GraphAttr(Pointer p) { super(p); }
 
   public GraphAttr(@ByVal Symbol name, @SharedPtr("torch::jit::Graph") @ByVal Graph value_) { super((Pointer)null); allocate(name, value_); }
-  private native void allocate(@ByVal Symbol name, @SharedPtr("torch::jit::Graph") @ByVal Graph value_);
+  @UniquePtr @Name("std::make_unique<torch::jit::GraphAttr>") private native void allocate(@ByVal Symbol name, @SharedPtr("torch::jit::Graph") @ByVal Graph value_);
   public native @SharedPtr("torch::jit::Graph") @ByRef Graph value();
   public native @UniquePtr @ByVal AttributeValue clone();
   public native JitAttributeKind kind();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/IStreamAdapter.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/IStreamAdapter.java
@@ -26,7 +26,7 @@ public class IStreamAdapter extends ReadAdapterInterface {
   
   
   public IStreamAdapter(@Cast("std::istream*") Pointer istream) { super((Pointer)null); allocate(istream); }
-  private native void allocate(@Cast("std::istream*") Pointer istream);
+  @UniquePtr @Name("std::make_unique<caffe2::serialize::IStreamAdapter>") private native void allocate(@Cast("std::istream*") Pointer istream);
   public native @Cast("size_t") long size();
   public native @Cast("size_t") long read(@Cast("uint64_t") long pos, Pointer buf, @Cast("size_t") long n, @Cast("const char*") BytePointer what/*=""*/);
   public native @Cast("size_t") long read(@Cast("uint64_t") long pos, Pointer buf, @Cast("size_t") long n);

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/LBFGSOptions.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/LBFGSOptions.java
@@ -25,9 +25,9 @@ public class LBFGSOptions extends OptimizerCloneableLBFGSOptions {
     public LBFGSOptions(Pointer p) { super(p); }
 
   public LBFGSOptions(double lr/*=1*/) { super((Pointer)null); allocate(lr); }
-  private native void allocate(double lr/*=1*/);
+  @UniquePtr @Name("std::make_unique<torch::optim::LBFGSOptions>") private native void allocate(double lr/*=1*/);
   public LBFGSOptions() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<torch::optim::LBFGSOptions>") private native void allocate();
   public native @ByRef @NoException(true) DoublePointer lr();
   public native @Cast("int64_t*") @ByRef @NoException(true) LongPointer max_iter();
   public native @ByRef @NoException(true) LongOptional max_eval();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/LBFGSParamState.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/LBFGSParamState.java
@@ -23,18 +23,9 @@ public class LBFGSParamState extends OptimizerCloneableLBFGSParamState {
     static { Loader.load(); }
     /** Default native constructor. */
     public LBFGSParamState() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public LBFGSParamState(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public LBFGSParamState(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public LBFGSParamState position(long position) {
-        return (LBFGSParamState)super.position(position);
-    }
-    @Override public LBFGSParamState getPointer(long i) {
-        return new LBFGSParamState((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::LBFGSParamState>") private native void allocate();
 
   public native @Cast("int64_t*") @ByRef @NoException(true) LongPointer func_evals();
   public native @Cast("int64_t*") @ByRef @NoException(true) LongPointer n_iter();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/NamedTensorMetaInterface.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/NamedTensorMetaInterface.java
@@ -21,20 +21,8 @@ import static org.bytedeco.pytorch.global.torch.*;
 @Namespace("c10") @Properties(inherit = org.bytedeco.pytorch.presets.torch.class)
 public class NamedTensorMetaInterface extends Pointer {
     static { Loader.load(); }
-    /** Default native constructor. */
-    public NamedTensorMetaInterface() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public NamedTensorMetaInterface(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public NamedTensorMetaInterface(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public NamedTensorMetaInterface position(long position) {
-        return (NamedTensorMetaInterface)super.position(position);
-    }
-    @Override public NamedTensorMetaInterface getPointer(long i) {
-        return new NamedTensorMetaInterface((Pointer)this).offsetAddress(i);
-    }
 
   public native @UniquePtr NamedTensorMetaInterface clone();
   public native @Cast("int64_t") long slow_dim();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/Node.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/Node.java
@@ -258,22 +258,22 @@ public class Node extends Pointer {
   // Hook API
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  public native @Cast("uintptr_t") long add_post_hook(@UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPostHook>&&"}) FunctionPostHook post_hook);
+  public native @Cast("uintptr_t") long add_post_hook(@UniquePtr @ByRef(true) FunctionPostHook post_hook);
 
   // delete a post hook matching the key
   public native @Cast("bool") boolean del_post_hook(@Cast("const uintptr_t") long key);
 
   public native @ByRef @NoException(true) FunctionPostHookVector post_hooks();
 
-  public native void add_pre_hook(@UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPreHook>&&"}) FunctionPreHook pre_hook);
+  public native void add_pre_hook(@UniquePtr @ByRef(true) FunctionPreHook pre_hook);
 
-  public native void add_tensor_pre_hook(@UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPreHook>&&"}) FunctionPreHook pre_hook);
+  public native void add_tensor_pre_hook(@UniquePtr @ByRef(true) FunctionPreHook pre_hook);
 
   public native void add_retains_grad_hook(
-        @UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPreHook>&&"}) FunctionPreHook pre_hook,
+        @UniquePtr @ByRef(true) FunctionPreHook pre_hook,
         int output_idx);
 
-  public native @UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPreHook>&&"}) FunctionPreHook pop_retains_grad_hook(int output_idx);
+  public native @UniquePtr @ByVal FunctionPreHook pop_retains_grad_hook(int output_idx);
 
   public native @ByRef @NoException(true) FunctionPreHookVector pre_hooks();
 

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/OperatorHandle.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/OperatorHandle.java
@@ -58,7 +58,7 @@ public class OperatorHandle extends Pointer {
 
   public native @ByVal TagArrayRef getTags();
 
-  public native void setReportErrorCallback_(@UniquePtr SafePyObject callback);
+  public native void setReportErrorCallback_(@UniquePtr @ByVal SafePyObject callback);
 
   public native @Cast("bool") boolean hasTag(Tag tag);
   public native @Cast("bool") boolean hasTag(@Cast("at::Tag") int tag);

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/OptimizerOptions.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/OptimizerOptions.java
@@ -23,20 +23,11 @@ public class OptimizerOptions extends Pointer {
     static { Loader.load(); }
     /** Default native constructor. */
     public OptimizerOptions() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public OptimizerOptions(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public OptimizerOptions(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public OptimizerOptions position(long position) {
-        return (OptimizerOptions)super.position(position);
-    }
-    @Override public OptimizerOptions getPointer(long i) {
-        return new OptimizerOptions((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::OptimizerOptions>") private native void allocate();
 
-  public native @UniquePtr OptimizerOptions clone();
+  public native @UniquePtr @ByVal OptimizerOptions clone();
   
   
   public native double get_lr();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/OptimizerParamGroup.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/OptimizerParamGroup.java
@@ -34,13 +34,13 @@ public class OptimizerParamGroup extends Pointer {
   private native void allocate(@Cast({"", "std::vector<torch::Tensor>"}) @StdMove TensorVector params);
   public OptimizerParamGroup(
         @Cast({"", "std::vector<torch::Tensor>"}) @StdMove TensorVector params,
-        @UniquePtr OptimizerOptions options) { super((Pointer)null); allocate(params, options); }
+        @UniquePtr @ByVal OptimizerOptions options) { super((Pointer)null); allocate(params, options); }
   private native void allocate(
         @Cast({"", "std::vector<torch::Tensor>"}) @StdMove TensorVector params,
-        @UniquePtr OptimizerOptions options);
+        @UniquePtr @ByVal OptimizerOptions options);
 
   public native @Cast("bool") boolean has_options();
   public native @ByRef OptimizerOptions options();
-  public native void set_options(@UniquePtr OptimizerOptions options);
+  public native void set_options(@UniquePtr @ByVal OptimizerOptions options);
   public native @ByRef TensorVector params();
 }

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/OptimizerParamState.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/OptimizerParamState.java
@@ -24,20 +24,11 @@ public class OptimizerParamState extends Pointer {
     static { Loader.load(); }
     /** Default native constructor. */
     public OptimizerParamState() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public OptimizerParamState(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public OptimizerParamState(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public OptimizerParamState position(long position) {
-        return (OptimizerParamState)super.position(position);
-    }
-    @Override public OptimizerParamState getPointer(long i) {
-        return new OptimizerParamState((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::OptimizerParamState>") private native void allocate();
 
-  public native @UniquePtr OptimizerParamState clone();
+  public native @UniquePtr @ByVal OptimizerParamState clone();
   
   
 }

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/RMSpropOptions.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/RMSpropOptions.java
@@ -25,9 +25,9 @@ public class RMSpropOptions extends OptimizerCloneableRMSpropOptions {
     public RMSpropOptions(Pointer p) { super(p); }
 
   public RMSpropOptions(double lr/*=1e-2*/) { super((Pointer)null); allocate(lr); }
-  private native void allocate(double lr/*=1e-2*/);
+  @UniquePtr @Name("std::make_unique<torch::optim::RMSpropOptions>") private native void allocate(double lr/*=1e-2*/);
   public RMSpropOptions() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<torch::optim::RMSpropOptions>") private native void allocate();
   public native @ByRef @NoException(true) DoublePointer lr();
   public native @ByRef @NoException(true) DoublePointer alpha();
   public native @ByRef @NoException(true) DoublePointer eps();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/RMSpropParamState.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/RMSpropParamState.java
@@ -23,18 +23,9 @@ public class RMSpropParamState extends OptimizerCloneableRMSpropParamState {
     static { Loader.load(); }
     /** Default native constructor. */
     public RMSpropParamState() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public RMSpropParamState(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public RMSpropParamState(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public RMSpropParamState position(long position) {
-        return (RMSpropParamState)super.position(position);
-    }
-    @Override public RMSpropParamState getPointer(long i) {
-        return new RMSpropParamState((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::RMSpropParamState>") private native void allocate();
 
   public native @Cast("int64_t*") @ByRef @NoException(true) LongPointer step();
   public native @ByRef @NoException(true) Tensor square_avg();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/SGDOptions.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/SGDOptions.java
@@ -25,7 +25,7 @@ public class SGDOptions extends OptimizerCloneableSGDOptions {
     public SGDOptions(Pointer p) { super(p); }
 
   public SGDOptions(double lr) { super((Pointer)null); allocate(lr); }
-  private native void allocate(double lr);
+  @UniquePtr @Name("std::make_unique<torch::optim::SGDOptions>") private native void allocate(double lr);
   public native @ByRef @NoException(true) DoublePointer lr();
   public native @ByRef @NoException(true) DoublePointer momentum();
   public native @ByRef @NoException(true) DoublePointer dampening();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/SGDParamState.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/SGDParamState.java
@@ -23,18 +23,9 @@ public class SGDParamState extends OptimizerCloneableSGDParamState {
     static { Loader.load(); }
     /** Default native constructor. */
     public SGDParamState() { super((Pointer)null); allocate(); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public SGDParamState(long size) { super((Pointer)null); allocateArray(size); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public SGDParamState(Pointer p) { super(p); }
-    private native void allocate();
-    private native void allocateArray(long size);
-    @Override public SGDParamState position(long position) {
-        return (SGDParamState)super.position(position);
-    }
-    @Override public SGDParamState getPointer(long i) {
-        return new SGDParamState((Pointer)this).offsetAddress(i);
-    }
+    @UniquePtr @Name("std::make_unique<torch::optim::SGDParamState>") private native void allocate();
 
   public native @ByRef @NoException(true) Tensor momentum_buffer();
   

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/SafePyObject.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/SafePyObject.java
@@ -38,9 +38,9 @@ public class SafePyObject extends Pointer {
 
   // Steals a reference to data
   public SafePyObject(@Cast("PyObject*") Pointer data, PyInterpreter pyinterpreter) { super((Pointer)null); allocate(data, pyinterpreter); }
-  private native void allocate(@Cast("PyObject*") Pointer data, PyInterpreter pyinterpreter);
+  @UniquePtr @Name("std::make_unique<c10::SafePyObject>") private native void allocate(@Cast("PyObject*") Pointer data, PyInterpreter pyinterpreter);
   public SafePyObject(@ByRef(true) SafePyObject other) { super((Pointer)null); allocate(other); }
-  private native void allocate(@ByRef(true) SafePyObject other);
+  @UniquePtr @Name("std::make_unique<c10::SafePyObject>") private native void allocate(@ByRef(true) SafePyObject other);
 
   // In principle this could be copyable if we add an incref to PyInterpreter
   // but for now it's easier to just disallow it.

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/TensorIterator.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/TensorIterator.java
@@ -23,21 +23,12 @@ public class TensorIterator extends TensorIteratorBase {
     static { Loader.load(); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public TensorIterator(Pointer p) { super(p); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public TensorIterator(long size) { super((Pointer)null); allocateArray(size); }
-    private native void allocateArray(long size);
-    @Override public TensorIterator position(long position) {
-        return (TensorIterator)super.position(position);
-    }
-    @Override public TensorIterator getPointer(long i) {
-        return new TensorIterator((Pointer)this).offsetAddress(i);
-    }
 
   public TensorIterator() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<at::TensorIterator>") private native void allocate();
   // Slicing is OK, TensorIterator guaranteed NOT to have any fields
   public TensorIterator(@Const @ByRef TensorIteratorBase iter) { super((Pointer)null); allocate(iter); }
-  private native void allocate(@Const @ByRef TensorIteratorBase iter);
+  @UniquePtr @Name("std::make_unique<at::TensorIterator>") private native void allocate(@Const @ByRef TensorIteratorBase iter);
 
 // #define TORCH_DISALLOW_TEMPORARIES(methodname)
 //   TORCH_DISALLOW_TEMPORARIES_IMPL(methodname, static)

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/TensorIteratorBase.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/TensorIteratorBase.java
@@ -108,7 +108,7 @@ public class TensorIteratorBase extends MetaBase {
 
   /** Splits this TensorIterator into two iterators. Together they iterate over
    *  the entire operation. Used by {@code with_32bit_indexing()}. */
-  public native @UniquePtr TensorIterator split(int dim);
+  public native @UniquePtr @ByVal TensorIterator split(int dim);
 
   /** Returns the dimension with the largest extent: (size[dim]-1) * stride[dim] */
   public native int get_dim_to_split();

--- a/pytorch/src/gen/java/org/bytedeco/pytorch/global/torch.java
+++ b/pytorch/src/gen/java/org/bytedeco/pytorch/global/torch.java
@@ -15140,7 +15140,7 @@ public static final int EXPECTED_MAX_LEVEL = 2;
 
 @Namespace("torch::autograd::impl") public static native void add_hook(
     @Const @ByRef TensorBase arg0,
-    @UniquePtr @Cast({"", "std::unique_ptr<torch::autograd::FunctionPreHook>&&"}) FunctionPreHook hook);
+    @UniquePtr @ByVal FunctionPreHook hook);
 @Namespace("torch::autograd::impl") public static native @ByRef FunctionPreHookVector hooks(@Cast("const torch::autograd::Variable*") @ByRef Tensor arg0);
 @Namespace("torch::autograd::impl") public static native void clear_hooks(@Const @ByRef TensorBase arg0);
 

--- a/tensorflow-lite/src/gen/java/org/bytedeco/tensorflowlite/Interpreter.java
+++ b/tensorflow-lite/src/gen/java/org/bytedeco/tensorflowlite/Interpreter.java
@@ -14,15 +14,6 @@ public class Interpreter extends Pointer {
     static { Loader.load(); }
     /** Pointer cast constructor. Invokes {@link Pointer#Pointer(Pointer)}. */
     public Interpreter(Pointer p) { super(p); }
-    /** Native array allocator. Access with {@link Pointer#position(long)}. */
-    public Interpreter(long size) { super((Pointer)null); allocateArray(size); }
-    private native void allocateArray(long size);
-    @Override public Interpreter position(long position) {
-        return (Interpreter)super.position(position);
-    }
-    @Override public Interpreter getPointer(long i) {
-        return new Interpreter((Pointer)this).offsetAddress(i);
-    }
 
   // Instantiate an interpreter. All errors associated with reading and
   // processing this model will be forwarded to the error_reporter object.
@@ -32,9 +23,9 @@ public class Interpreter extends Pointer {
   // WARNING: Use of this constructor outside of an InterpreterBuilder is not
   // recommended.
   public Interpreter(ErrorReporter error_reporter/*=tflite::DefaultErrorReporter()*/) { super((Pointer)null); allocate(error_reporter); }
-  private native void allocate(ErrorReporter error_reporter/*=tflite::DefaultErrorReporter()*/);
+  @UniquePtr @Name("std::make_unique<tflite::impl::Interpreter>") private native void allocate(ErrorReporter error_reporter/*=tflite::DefaultErrorReporter()*/);
   public Interpreter() { super((Pointer)null); allocate(); }
-  private native void allocate();
+  @UniquePtr @Name("std::make_unique<tflite::impl::Interpreter>") private native void allocate();
 
   // Interpreters are not copyable as they have non-trivial memory semantics.
   

--- a/tensorflow-lite/src/gen/java/org/bytedeco/tensorflowlite/Subgraph.java
+++ b/tensorflow-lite/src/gen/java/org/bytedeco/tensorflowlite/Subgraph.java
@@ -25,7 +25,7 @@ public class Subgraph extends Pointer {
              @Cast("tflite::resource::ResourceIDMap*") StringIntMap resource_ids,
              @Cast("tflite::resource::InitializationStatusMap*") IntResourceBaseMap initialization_status_map,
              int subgraph_index/*=kInvalidSubgraphIndex*/) { super((Pointer)null); allocate(error_reporter, external_contexts, subgraphs, resources, resource_ids, initialization_status_map, subgraph_index); }
-  private native void allocate(ErrorReporter error_reporter,
+  @UniquePtr @Name("std::make_unique<tflite::Subgraph>") private native void allocate(ErrorReporter error_reporter,
              @Cast("TfLiteExternalContext**") PointerPointer external_contexts,
              SubgraphVector subgraphs,
              @Cast("tflite::resource::ResourceMap*") IntResourceBaseMap resources,
@@ -38,7 +38,7 @@ public class Subgraph extends Pointer {
              @Cast("tflite::resource::ResourceMap*") IntResourceBaseMap resources,
              @Cast("tflite::resource::ResourceIDMap*") StringIntMap resource_ids,
              @Cast("tflite::resource::InitializationStatusMap*") IntResourceBaseMap initialization_status_map) { super((Pointer)null); allocate(error_reporter, external_contexts, subgraphs, resources, resource_ids, initialization_status_map); }
-  private native void allocate(ErrorReporter error_reporter,
+  @UniquePtr @Name("std::make_unique<tflite::Subgraph>") private native void allocate(ErrorReporter error_reporter,
              @ByPtrPtr TfLiteExternalContext external_contexts,
              SubgraphVector subgraphs,
              @Cast("tflite::resource::ResourceMap*") IntResourceBaseMap resources,
@@ -51,7 +51,7 @@ public class Subgraph extends Pointer {
              @Cast("tflite::resource::ResourceIDMap*") StringIntMap resource_ids,
              @Cast("tflite::resource::InitializationStatusMap*") IntResourceBaseMap initialization_status_map,
              int subgraph_index/*=kInvalidSubgraphIndex*/) { super((Pointer)null); allocate(error_reporter, external_contexts, subgraphs, resources, resource_ids, initialization_status_map, subgraph_index); }
-  private native void allocate(ErrorReporter error_reporter,
+  @UniquePtr @Name("std::make_unique<tflite::Subgraph>") private native void allocate(ErrorReporter error_reporter,
              @ByPtrPtr TfLiteExternalContext external_contexts,
              SubgraphVector subgraphs,
              @Cast("tflite::resource::ResourceMap*") IntResourceBaseMap resources,
@@ -63,7 +63,7 @@ public class Subgraph extends Pointer {
 
   // Subgraphs should be movable but not copyable.
   public Subgraph(@StdMove Subgraph arg0) { super((Pointer)null); allocate(arg0); }
-  private native void allocate(@StdMove Subgraph arg0);
+  @UniquePtr @Name("std::make_unique<tflite::Subgraph>") private native void allocate(@StdMove Subgraph arg0);
   
 
   // Provide a list of tensor indexes that are inputs to the model.

--- a/tensorflow-lite/src/main/java/org/bytedeco/tensorflowlite/presets/tensorflowlite.java
+++ b/tensorflow-lite/src/main/java/org/bytedeco/tensorflowlite/presets/tensorflowlite.java
@@ -170,6 +170,10 @@ public class tensorflowlite implements InfoMapper {
                .put(new Info("tflite::impl::Interpreter::typed_output_tensor<double>").javaNames("typed_output_tensor_double"))
                .put(new Info("tflite::impl::Interpreter::typed_output_tensor<bool>").javaNames("typed_output_tensor_bool"))
                .put(new Info("tflite::impl::Interpreter::typed_output_tensor<TfLiteFloat16>").javaNames("typed_input_tensor_float16"))
+
+                // Classes passed to some native functions as unique_ptr and that can be allocated Java-side
+               .put(new Info("tflite::impl::Interpreter::Interpreter").annotations("@UniquePtr", "@Name(\"std::make_unique<tflite::impl::Interpreter>\")"))
+               .put(new Info("tflite::Subgraph::Subgraph").annotations("@UniquePtr", "@Name(\"std::make_unique<tflite::Subgraph>\")"))
         ;
     }
 }


### PR DESCRIPTION
When a native function takes a `unique_ptr` to some class as an argument  AND if that class can be instantiated from Java, the Java constructors must by annotated with `@UniquePtr` and `@Name`. 

Affected presets: Pytorch and Tensorflow-lite.