### PR TITLE
Add PyTorch macosx-arm64 cross-compiled build

### DIFF
--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -32,6 +32,10 @@ jobs:
           path: /home/runner/.ccache
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
         timeout-minutes: 350
+  macosx-arm64:
+    runs-on: macos-11
+    steps:
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-macosx@actions
   macosx-x86_64:
     runs-on: macos-11
 #    strategy:
@@ -61,7 +65,7 @@ jobs:
       - uses: bytedeco/javacpp-presets/.github/actions/deploy-windows@actions
         timeout-minutes: 350
   redeploy:
-    needs: [linux-x86_64, macosx-x86_64, windows-x86_64]
+    needs: [linux-x86_64, macosx-arm64, macosx-x86_64, windows-x86_64]
     runs-on: ubuntu-20.04
     steps:
       - uses: bytedeco/javacpp-presets/.github/actions/redeploy@actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Introduce `macosx-arm64` builds for PyTorch ([pull #1463](https://github.com/bytedeco/javacpp-presets/pull/1463))
  * Enable Vulkan GPU acceleration for FFmpeg ([pull #1460](https://github.com/bytedeco/javacpp-presets/pull/1460))
  * Include `timeapi.h` for system API of Windows ([pull #1447](https://github.com/bytedeco/javacpp-presets/pull/1447))
  * Add Android and Windows builds to presets for DepthAI ([pull #1441](https://github.com/bytedeco/javacpp-presets/pull/1441))

--- a/pom.xml
+++ b/pom.xml
@@ -1466,8 +1466,8 @@
         <module>libpostal</module>
         <module>libraw</module>
         <module>leptonica</module>
-        <module>pytorch</module>
         <module>tesseract</module>
+        <module>pytorch</module>
         <module>sentencepiece</module>
       </modules>
       <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1466,6 +1466,7 @@
         <module>libpostal</module>
         <module>libraw</module>
         <module>leptonica</module>
+        <module>pytorch</module>
         <module>tesseract</module>
         <module>sentencepiece</module>
       </modules>

--- a/pytorch/cppbuild.sh
+++ b/pytorch/cppbuild.sh
@@ -57,6 +57,10 @@ git submodule foreach --recursive 'git reset --hard'
 #patch -Np1 < ../../../pytorch.patch
 
 CPYTHON_PATH="$INSTALL_PATH/../../../cpython/cppbuild/$PLATFORM/"
+# local cross-compilation requires x86_64 cpython
+if [ "$ARCH" = "x86_64" ] && [ "$PLATFORM" = "macosx-arm64" ]; then
+  CPYTHON_PATH="$INSTALL_PATH/../../../cpython/cppbuild/macosx-x86_64/"
+fi
 OPENBLAS_PATH="$INSTALL_PATH/../../../openblas/cppbuild/$PLATFORM/"
 NUMPY_PATH="$INSTALL_PATH/../../../numpy/cppbuild/$PLATFORM/"
 
@@ -122,9 +126,10 @@ case $PLATFORM in
     macosx-arm64)
         export CC="clang"
         export CXX="clang++"
-        export CMAKE_OSX_ARCHITECTURES=arm64 # enables cross-compilation
+        export CMAKE_OSX_ARCHITECTURES=arm64 # enable cross-compilation on a x86_64 host machine
         export USE_MKLDNN=OFF
-        export CMAKE_OSX_DEPLOYMENT_TARGET=11.00
+        export USE_QNNPACK=OFF # not compatible with arm64 as of PyTorch 2.1.2
+        export CMAKE_OSX_DEPLOYMENT_TARGET=11.00 # minimum needed for arm64 support
         ;;
     windows-x86_64)
         if which ccache.exe; then

--- a/pytorch/cppbuild.sh
+++ b/pytorch/cppbuild.sh
@@ -86,7 +86,7 @@ CPYTHON_PATH="${CPYTHON_PATH//\\//}"
 OPENBLAS_PATH="${OPENBLAS_PATH//\\//}"
 NUMPY_PATH="${NUMPY_PATH//\\//}"
 
-CPYTHON_PATH=CPYTHON_HOST_PATH
+CPYTHON_PATH="$CPYTHON_HOST_PATH"
 if [[ -f "$CPYTHON_PATH/include/python3.12/Python.h" ]]; then
     # setup.py won't pick up the right libgfortran.so without this
     export LD_LIBRARY_PATH="$OPENBLAS_PATH/lib/:$CPYTHON_PATH/lib/:$NUMPY_PATH/lib/"

--- a/pytorch/cppbuild.sh
+++ b/pytorch/cppbuild.sh
@@ -86,41 +86,33 @@ CPYTHON_PATH="${CPYTHON_PATH//\\//}"
 OPENBLAS_PATH="${OPENBLAS_PATH//\\//}"
 NUMPY_PATH="${NUMPY_PATH//\\//}"
 
-export PYTHONNOUSERSITE=1
-
-TOOLS="setuptools==67.6.1 pyyaml==6.0.1 typing_extensions==4.8.0"
-
-if [[ $PLATFORM == $PLATFORM_HOST ]]; then
-    if [[ -f "$CPYTHON_PATH/include/python3.12/Python.h" ]]; then
-        # setup.py won't pick up the right libgfortran.so without this
-        export LD_LIBRARY_PATH="$OPENBLAS_PATH/lib/:$CPYTHON_PATH/lib/:$NUMPY_PATH/lib/"
-        export PYTHON_BIN_PATH="$CPYTHON_PATH/bin/python3.12"
-        export PYTHON_INCLUDE_PATH="$CPYTHON_PATH/include/python3.12/"
-        export PYTHON_LIB_PATH="$CPYTHON_PATH/lib/python3.12/"
-        export PYTHON_INSTALL_PATH="$INSTALL_PATH/lib/python3.12/site-packages/"
-        export SSL_CERT_FILE="$CPYTHON_PATH/lib/python3.12/site-packages/pip/_vendor/certifi/cacert.pem"
-        chmod +x "$PYTHON_BIN_PATH"
-    elif [[ -f "$CPYTHON_PATH/include/Python.h" ]]; then
-        CPYTHON_PATH=$(cygpath $CPYTHON_PATH)
-        OPENBLAS_PATH=$(cygpath $OPENBLAS_PATH)
-        NUMPY_PATH=$(cygpath $NUMPY_PATH)
-        export PATH="$OPENBLAS_PATH:$CPYTHON_PATH:$NUMPY_PATH:$PATH"
-        export PYTHON_BIN_PATH="$CPYTHON_PATH/bin/python.exe"
-        export PYTHON_INCLUDE_PATH="$CPYTHON_PATH/include/"
-        export PYTHON_LIB_PATH="$CPYTHON_PATH/lib/"
-        export PYTHON_INSTALL_PATH="$INSTALL_PATH/lib/site-packages/"
-        export SSL_CERT_FILE="$CPYTHON_PATH/lib/pip/_vendor/certifi/cacert.pem"
-    fi
-    export PYTHONPATH="$PYTHON_INSTALL_PATH:$NUMPY_PATH/python/"
-    mkdir -p "$PYTHON_INSTALL_PATH"
-
-    export CFLAGS="-I$CPYTHON_PATH/include/ -I$PYTHON_LIB_PATH/include/python/ -L$CPYTHON_PATH/lib/ -L$CPYTHON_PATH/libs/"
-    $PYTHON_BIN_PATH -m pip install --target=$PYTHON_LIB_PATH $TOOLS
-else # cross-compile
-    export PYTHON_BIN_PATH="$CPYTHON_HOST_PATH/bin/python3.12"
-    chmod +x $PYTHON_BIN_PATH
-    $PYTHON_BIN_PATH -m pip install --target="$CPYTHON_HOST_PATH/lib/python3.12/" $TOOLS
+CPYTHON_PATH=CPYTHON_HOST_PATH
+if [[ -f "$CPYTHON_PATH/include/python3.12/Python.h" ]]; then
+    # setup.py won't pick up the right libgfortran.so without this
+    export LD_LIBRARY_PATH="$OPENBLAS_PATH/lib/:$CPYTHON_PATH/lib/:$NUMPY_PATH/lib/"
+    export PYTHON_BIN_PATH="$CPYTHON_PATH/bin/python3.12"
+    export PYTHON_INCLUDE_PATH="$CPYTHON_PATH/include/python3.12/"
+    export PYTHON_LIB_PATH="$CPYTHON_PATH/lib/python3.12/"
+    export PYTHON_INSTALL_PATH="$INSTALL_PATH/lib/python3.12/site-packages/"
+    export SSL_CERT_FILE="$CPYTHON_PATH/lib/python3.12/site-packages/pip/_vendor/certifi/cacert.pem"
+    chmod +x "$PYTHON_BIN_PATH"
+elif [[ -f "$CPYTHON_PATH/include/Python.h" ]]; then
+    CPYTHON_PATH=$(cygpath $CPYTHON_PATH)
+    OPENBLAS_PATH=$(cygpath $OPENBLAS_PATH)
+    NUMPY_PATH=$(cygpath $NUMPY_PATH)
+    export PATH="$OPENBLAS_PATH:$CPYTHON_PATH:$NUMPY_PATH:$PATH"
+    export PYTHON_BIN_PATH="$CPYTHON_PATH/bin/python.exe"
+    export PYTHON_INCLUDE_PATH="$CPYTHON_PATH/include/"
+    export PYTHON_LIB_PATH="$CPYTHON_PATH/lib/"
+    export PYTHON_INSTALL_PATH="$INSTALL_PATH/lib/site-packages/"
+    export SSL_CERT_FILE="$CPYTHON_PATH/lib/pip/_vendor/certifi/cacert.pem"
 fi
+export PYTHONPATH="$PYTHON_INSTALL_PATH:$NUMPY_PATH/python/"
+mkdir -p "$PYTHON_INSTALL_PATH"
+
+export CFLAGS="-I$CPYTHON_PATH/include/ -I$PYTHON_LIB_PATH/include/python/ -L$CPYTHON_PATH/lib/ -L$CPYTHON_PATH/libs/"
+export PYTHONNOUSERSITE=1
+$PYTHON_BIN_PATH -m pip install --target=$PYTHON_LIB_PATH setuptools==67.6.1 pyyaml==6.0.1 typing_extensions==4.8.0
 
 case $PLATFORM in
     linux-x86)
@@ -131,10 +123,6 @@ case $PLATFORM in
         export CC="gcc -m64"
         export CXX="g++ -m64"
         ;;
-    macosx-x86_64)
-        export CC="clang"
-        export CXX="clang++"
-        ;;
     macosx-arm64)
         export CC="clang"
         export CXX="clang++"
@@ -142,6 +130,10 @@ case $PLATFORM in
         export USE_MKLDNN=OFF
         export USE_QNNPACK=OFF # not compatible with arm64 as of PyTorch 2.1.2
         export CMAKE_OSX_DEPLOYMENT_TARGET=11.00 # minimum needed for arm64 support
+        ;;
+    macosx-x86_64)
+        export CC="clang"
+        export CXX="clang++"
         ;;
     windows-x86_64)
         if which ccache.exe; then

--- a/pytorch/cppbuild.sh
+++ b/pytorch/cppbuild.sh
@@ -115,9 +115,16 @@ case $PLATFORM in
         export CC="gcc -m64"
         export CXX="g++ -m64"
         ;;
-    macosx-*)
+    macosx-x86_64)
         export CC="clang"
         export CXX="clang++"
+        ;;
+    macosx-arm64)
+        export CC="clang"
+        export CXX="clang++"
+        export CMAKE_OSX_ARCHITECTURES=arm64 # enables cross-compilation
+        export USE_MKLDNN=OFF
+        export CMAKE_OSX_DEPLOYMENT_TARGET=11.00
         ;;
     windows-x86_64)
         if which ccache.exe; then

--- a/pytorch/platform/gpu/pom.xml
+++ b/pytorch/platform/gpu/pom.xml
@@ -32,12 +32,6 @@
       <version>0.3.26-${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>numpy-platform</artifactId>
-      <version>1.26.3-${project.parent.version}</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>

--- a/pytorch/platform/pom.xml
+++ b/pytorch/platform/pom.xml
@@ -31,12 +31,6 @@
       <version>0.3.26-${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>numpy-platform</artifactId>
-      <version>1.26.3-${project.parent.version}</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>

--- a/pytorch/pom.xml
+++ b/pytorch/pom.xml
@@ -24,12 +24,6 @@
       <artifactId>openblas</artifactId>
       <version>0.3.26-${project.parent.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.bytedeco</groupId>
-      <artifactId>numpy</artifactId>
-      <version>1.26.3-${project.parent.version}</version>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 
   <build>
@@ -53,6 +47,12 @@
             <groupId>org.bytedeco</groupId>
             <artifactId>numpy-platform</artifactId>
             <version>1.26.3-${project.parent.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>cpython</artifactId>
+            <version>3.12.1-${project.parent.version}</version>
+            <classifier>${os.name}-${os.arch}</classifier>
           </dependency>
         </dependencies>
         <configuration>
@@ -136,46 +136,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <!-- cross-compilation profile for macosx-arm64 builds on macosx-x86_64 CI machines -->
-  <profiles>
-    <profile>
-      <id>pytorch-cross-compile</id>
-      <activation>
-        <property>
-          <name>javacpp.platform</name>
-          <value>macosx-arm64</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.bytedeco</groupId>
-            <artifactId>javacpp</artifactId>
-            <dependencies>
-              <dependency>
-                <groupId>org.bytedeco</groupId>
-                <artifactId>cpython</artifactId>
-                <version>3.12.1-${project.parent.version}</version>
-                <classifier>${os.name}-${os.arch}</classifier>
-              </dependency>
-              <!-- we need to exclude target cpython until we have a macosx-arm64 build -->
-              <dependency>
-                <groupId>org.bytedeco</groupId>
-                <artifactId>numpy-platform</artifactId>
-                <version>1.26.3-${project.parent.version}</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>org.bytedeco</groupId>
-                    <artifactId>cpython</artifactId>
-                  </exclusion>
-                </exclusions>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/pytorch/pom.xml
+++ b/pytorch/pom.xml
@@ -91,6 +91,8 @@
             <buildResource>/${javacpp.platform.library.path}/</buildResource>
             <buildResource>/org/bytedeco/openblas/${javacpp.platform}/</buildResource>
             <buildResource>/org/bytedeco/cpython/${javacpp.platform}/</buildResource>
+            <!-- add host cpython for running setup.py when cross-compiling -->
+            <buildResource>/org/bytedeco/cpython/${os.name}-${os.arch}/</buildResource>
             <buildResource>/org/bytedeco/mkldnn/${javacpp.platform}/</buildResource>
             <buildResource>/org/bytedeco/numpy/${javacpp.platform}/</buildResource>
           </buildResources>
@@ -138,7 +140,7 @@
   <!-- cross-compilation profile for macosx-arm64 builds on macosx-x86_64 CI machines -->
   <profiles>
     <profile>
-      <id>macosx-arm64</id>
+      <id>pytorch-cross-compile</id>
       <activation>
         <property>
           <name>javacpp.platform</name>
@@ -153,54 +155,23 @@
             <dependencies>
               <dependency>
                 <groupId>org.bytedeco</groupId>
-                <artifactId>openblas-platform</artifactId>
-                <version>0.3.25-${project.parent.version}</version>
-              </dependency>
-              <dependency>
-                <groupId>org.bytedeco</groupId>
                 <artifactId>cpython</artifactId>
                 <version>3.12.1-${project.parent.version}</version>
-                <classifier>macosx-x86_64</classifier>
+                <classifier>${os.name}-${os.arch}</classifier>
+              </dependency>
+              <!-- we need to exclude target cpython until we have a macosx-arm64 build -->
+              <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>numpy-platform</artifactId>
+                <version>1.26.3-${project.parent.version}</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>org.bytedeco</groupId>
+                    <artifactId>cpython</artifactId>
+                  </exclusion>
+                </exclusions>
               </dependency>
             </dependencies>
-            <configuration>
-              <classPaths>
-                <classPath>${basedir}/../openblas/target/classes/</classPath>
-                <classPath>${project.build.outputDirectory}</classPath>
-              </classPaths>
-              <includePaths>
-                <includePath>${basedir}/../openblas/src/main/resources/org/bytedeco/openblas/include/</includePath>
-                <includePath>${basedir}/../openblas/target/classes/org/bytedeco/openblas/include/</includePath>
-                <includePath>${basedir}/../openblas/cppbuild/${javacpp.platform}/include/</includePath>
-                <includePath>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/include/torch/csrc/api/include/</includePath>
-                <includePath>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/include/</includePath>
-                <includePath>${basedir}/target/classes/org/bytedeco/${javacpp.packageName}/include/</includePath>
-              </includePaths>
-              <linkPaths>
-                <linkPath>${basedir}/../openblas/cppbuild/${javacpp.platform}/lib/</linkPath>
-                <linkPath>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/lib/</linkPath>
-              </linkPaths>
-              <preloadPaths>
-                <preloadPath>${basedir}/../openblas/cppbuild/${javacpp.platform}/bin/</preloadPath>
-              </preloadPaths>
-              <buildResources>
-                <buildResource>/${javacpp.platform.library.path}/</buildResource>
-                <buildResource>/org/bytedeco/openblas/${javacpp.platform}/</buildResource>
-                <!-- add host cpython for running setup.py when cross-compiling -->
-                <buildResource>/org/bytedeco/cpython/macosx-x86_64/</buildResource>
-              </buildResources>
-              <includeResources>
-                <includeResource>/${javacpp.platform.library.path}/include/</includeResource>
-                <includeResource>/org/bytedeco/openblas/include/</includeResource>
-                <includeResource>/org/bytedeco/openblas/${javacpp.platform}/include/</includeResource>
-              </includeResources>
-              <linkResources>
-                <linkResource>/${javacpp.platform.library.path}/</linkResource>
-                <linkResource>/${javacpp.platform.library.path}/lib/</linkResource>
-                <linkResource>/org/bytedeco/openblas/${javacpp.platform}/</linkResource>
-                <linkResource>/org/bytedeco/openblas/${javacpp.platform}/lib/</linkResource>
-              </linkResources>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pytorch/pom.xml
+++ b/pytorch/pom.xml
@@ -135,4 +135,76 @@
     </plugins>
   </build>
 
+  <!-- cross-compilation profile for macosx-arm64 builds on macosx-x86_64 CI machines -->
+  <profiles>
+    <profile>
+      <id>macosx-arm64</id>
+      <activation>
+        <property>
+          <name>javacpp.platform</name>
+          <value>macosx-arm64</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>openblas-platform</artifactId>
+                <version>0.3.25-${project.parent.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>cpython</artifactId>
+                <version>3.12.1-${project.parent.version}</version>
+                <classifier>macosx-x86_64</classifier>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <classPaths>
+                <classPath>${basedir}/../openblas/target/classes/</classPath>
+                <classPath>${project.build.outputDirectory}</classPath>
+              </classPaths>
+              <includePaths>
+                <includePath>${basedir}/../openblas/src/main/resources/org/bytedeco/openblas/include/</includePath>
+                <includePath>${basedir}/../openblas/target/classes/org/bytedeco/openblas/include/</includePath>
+                <includePath>${basedir}/../openblas/cppbuild/${javacpp.platform}/include/</includePath>
+                <includePath>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/include/torch/csrc/api/include/</includePath>
+                <includePath>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/include/</includePath>
+                <includePath>${basedir}/target/classes/org/bytedeco/${javacpp.packageName}/include/</includePath>
+              </includePaths>
+              <linkPaths>
+                <linkPath>${basedir}/../openblas/cppbuild/${javacpp.platform}/lib/</linkPath>
+                <linkPath>${basedir}/cppbuild/${javacpp.platform}${javacpp.platform.extension}/lib/</linkPath>
+              </linkPaths>
+              <preloadPaths>
+                <preloadPath>${basedir}/../openblas/cppbuild/${javacpp.platform}/bin/</preloadPath>
+              </preloadPaths>
+              <buildResources>
+                <buildResource>/${javacpp.platform.library.path}/</buildResource>
+                <buildResource>/org/bytedeco/openblas/${javacpp.platform}/</buildResource>
+                <!-- add host cpython for running setup.py when cross-compiling -->
+                <buildResource>/org/bytedeco/cpython/macosx-x86_64/</buildResource>
+              </buildResources>
+              <includeResources>
+                <includeResource>/${javacpp.platform.library.path}/include/</includeResource>
+                <includeResource>/org/bytedeco/openblas/include/</includeResource>
+                <includeResource>/org/bytedeco/openblas/${javacpp.platform}/include/</includeResource>
+              </includeResources>
+              <linkResources>
+                <linkResource>/${javacpp.platform.library.path}/</linkResource>
+                <linkResource>/${javacpp.platform.library.path}/lib/</linkResource>
+                <linkResource>/org/bytedeco/openblas/${javacpp.platform}/</linkResource>
+                <linkResource>/org/bytedeco/openblas/${javacpp.platform}/lib/</linkResource>
+              </linkResources>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Fixes #1461 

Add PyTorch cross-compilation `macosx-x86_64` -> `macosx-arm64`. The idea is to use the host Python interpreter to run `setup.py build` See #1461 for more details about this. Cross-compilation settings are derived from the [PyTorch builder](https://github.com/pytorch/builder/blob/74b04f302afede5c25275d8026f34a06330cc515/wheel/build_wheel.sh#L201-L206).

After some experimentation, I figured out that we can use a Maven profile to to use the host Python interpreter for cross-compilation in CI without affecting the existing native builds.

Since we're building just the C++ part of PyTorch (LibTorch), I think it should be OK to add the host Python interpreter like this. We might need to adapt a little bit once we have CPython and NumPy for arm, if it requires running the host Python but also linking against target libpython but I'm not sure (see #1461).

Perhaps a somewhat cleaner approach could be trying to keep `$CPYTHON_PATH` set to the `$PLATFORM` cpython and get the host interpreter out another way in the build script but that would need some more experimentations.

@saudet what do you think?

BTW I also tried cross-compiling cpython as well before realizing that we need the host interpreter for running `setup.py` but couldn't get it working as it's not really supported currently. See [Support cross compilation on macOS #90905](https://github.com/python/cpython/issues/90905). Perhaps GitHub will provide free native macosx-arm64 runners at some point which should make this easier.

#1069