### PR TITLE
Fixed segfault in LLVM Orc example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Update and fix the sample code of the presets for LLVM ([pull #1501](https://github.com/bytedeco/javacpp-presets/pull/1501))
  * Fix Vulkan GPU acceleration for FFmpeg ([pull #1497](https://github.com/bytedeco/javacpp-presets/pull/1497))
  * Build FFmpeg with zimg to enable zscale filter ([pull #1481](https://github.com/bytedeco/javacpp-presets/pull/1481))
  * Enable PulseAudio support for FFmpeg on Linux ([pull #1472](https://github.com/bytedeco/javacpp-presets/pull/1472))

--- a/llvm/README.md
+++ b/llvm/README.md
@@ -75,8 +75,8 @@ public class Factorial {
 
     public static void main(String[] args) {
         // Stage 1: Initialize LLVM components
-	    LLVMInitializeNativeTarget();
-	    LLVMInitializeNativeAsmPrinter();
+        LLVMInitializeNativeTarget();
+        LLVMInitializeNativeAsmPrinter();
 
         // Stage 2: Build the factorial function.
         LLVMContextRef context = LLVMContextCreate();

--- a/llvm/README.md
+++ b/llvm/README.md
@@ -61,6 +61,8 @@ We can use [Maven 3](http://maven.apache.org/) to download and install automatic
 
 ### The `Factorial.java` source file
 
+This example is based on MCJIT. There is a newer alternative called ORC. You can find an example using ORC [here](samples/llvm/OrcJit.java).
+
 ```java
 import org.bytedeco.javacpp.*;
 import org.bytedeco.llvm.LLVM.*;
@@ -73,11 +75,8 @@ public class Factorial {
 
     public static void main(String[] args) {
         // Stage 1: Initialize LLVM components
-        LLVMInitializeCore(LLVMGetGlobalPassRegistry());
-        LLVMLinkInMCJIT();
-        LLVMInitializeNativeAsmPrinter();
-        LLVMInitializeNativeAsmParser();
-        LLVMInitializeNativeTarget();
+	    LLVMInitializeNativeTarget();
+	    LLVMInitializeNativeAsmPrinter();
 
         // Stage 2: Build the factorial function.
         LLVMContextRef context = LLVMContextCreate();
@@ -119,6 +118,9 @@ public class Factorial {
         LLVMAddIncoming(phi, phiValues, phiBlocks, /* pairCount */ 2);
         LLVMBuildRet(builder, phi);
 
+	    // Print generated LLVM-IR to console (optional)
+	    LLVMDumpModule(module);
+
         // Stage 3: Verify the module using LLVMVerifier
         if (LLVMVerifyModule(module, LLVMPrintMessageAction, error) != 0) {
             LLVMDisposeMessage(error);
@@ -127,11 +129,7 @@ public class Factorial {
 
         // Stage 4: Create a pass pipeline using the legacy pass manager
         LLVMPassManagerRef pm = LLVMCreatePassManager();
-        LLVMAddAggressiveInstCombinerPass(pm);
-        LLVMAddNewGVNPass(pm);
-        LLVMAddCFGSimplificationPass(pm);
         LLVMRunPassManager(pm, module);
-        LLVMDumpModule(module);
 
         // Stage 5: Execute the code using MCJIT
         LLVMExecutionEngineRef engine = new LLVMExecutionEngineRef();
@@ -145,8 +143,8 @@ public class Factorial {
         LLVMGenericValueRef argument = LLVMCreateGenericValueOfInt(i32Type, 10, /* signExtend */ 0);
         LLVMGenericValueRef result = LLVMRunFunction(engine, factorial, /* argumentCount */ 1, argument);
         System.out.println();
-        System.out.println("; Running factorial(10) with MCJIT...");
-        System.out.println("; Result: " + LLVMGenericValueToInt(result, /* signExtend */ 0));
+        System.out.println("Running factorial(10) with MCJIT...");
+        System.out.println("Result: " + LLVMGenericValueToInt(result, /* signExtend */ 0));
 
         // Stage 6: Dispose of the allocated resources
         LLVMDisposeExecutionEngine(engine);

--- a/llvm/README.md
+++ b/llvm/README.md
@@ -118,8 +118,8 @@ public class Factorial {
         LLVMAddIncoming(phi, phiValues, phiBlocks, /* pairCount */ 2);
         LLVMBuildRet(builder, phi);
 
-	    // Print generated LLVM-IR to console (optional)
-	    LLVMDumpModule(module);
+        // Print generated LLVM-IR to console (optional)
+        LLVMDumpModule(module);
 
         // Stage 3: Verify the module using LLVMVerifier
         if (LLVMVerifyModule(module, LLVMPrintMessageAction, error) != 0) {

--- a/llvm/samples/llvm/EmitBitcode.java
+++ b/llvm/samples/llvm/EmitBitcode.java
@@ -69,10 +69,8 @@ public class EmitBitcode {
      */
     public static void EmitBitcodeAndRelocatableObject() {
         // Stage 1: Initialize LLVM components
-        LLVMInitializeNativeAsmPrinter();
-        LLVMInitializeNativeAsmParser();
-        LLVMInitializeNativeDisassembler();
         LLVMInitializeNativeTarget();
+        LLVMInitializeNativeAsmPrinter();
 
         // Stage 2: Build the sum function
         LLVMContextRef context = LLVMContextCreate();
@@ -156,8 +154,6 @@ public class EmitBitcode {
      */
     public static void EvaluateBitcode() {
         // Stage 1: Initialize LLVM components
-        LLVMInitializeNativeAsmPrinter();
-        LLVMInitializeNativeAsmParser();
         LLVMInitializeNativeTarget();
 
         // Stage 2: Load and parse bitcode
@@ -208,8 +204,6 @@ public class EmitBitcode {
             case "-evaluate":
                 EvaluateBitcode();
                 System.exit(0);
-            default:
-                // Display help
         }
         System.err.println("Pass `-emit` or `-evaluate`.");
         System.exit(1);

--- a/llvm/samples/llvm/EmitBitcode.java
+++ b/llvm/samples/llvm/EmitBitcode.java
@@ -45,7 +45,7 @@ import static org.bytedeco.llvm.global.LLVM.*;
  * <p>
  * The EvaluateBitcode sample depends on EmitBitcodeAndRelocatableObject
  * <p>
- * The samples should be ran in declaration order, meaning EmitBitcodeAndRelocatableObject
+ * The samples should be called in declaration order, meaning EmitBitcodeAndRelocatableObject
  * should run before EvaluateBitcode.
  */
 public class EmitBitcode {
@@ -54,7 +54,7 @@ public class EmitBitcode {
     /**
      * Sample for generating both LLVM bitcode and relocatable object file from an LLVM module
      * <p>
-     * The generated module (and objec file) will have a single sum function, which returns
+     * The generated module (and object file) will have a single 'sum' function, which returns
      * the sum of two integers.
      * <p>
      * declare i32 @sum(i32 %lhs, i32 %rhs)
@@ -69,7 +69,6 @@ public class EmitBitcode {
      */
     public static void EmitBitcodeAndRelocatableObject() {
         // Stage 1: Initialize LLVM components
-//        LLVMInitializeCore(LLVMGetGlobalPassRegistry());
         LLVMInitializeNativeAsmPrinter();
         LLVMInitializeNativeAsmParser();
         LLVMInitializeNativeDisassembler();
@@ -143,10 +142,10 @@ public class EmitBitcode {
 
     /**
      * Sample code for importing a LLVM bitcode file and running a function
-     * inside of the imported module
+     * from the imported module
      * <p>
-     * This sample depends on EmitBitcode to produce the bitcode file. Make sure
-     * you've ran the EmitBitcode sample and have the 'sum.bc' bitcode file.
+     * This sample depends on EmitBitcodeAndRelocatableObject to produce the bitcode file.
+     * Make sure you ran the EmitBitcodeAndRelocatableObject sample and have the 'sum.bc' bitcode file.
      * <p>
      * This sample contains code for the following steps:
      * <p>
@@ -157,7 +156,6 @@ public class EmitBitcode {
      */
     public static void EvaluateBitcode() {
         // Stage 1: Initialize LLVM components
-//        LLVMInitializeCore(LLVMGetGlobalPassRegistry());
         LLVMInitializeNativeAsmPrinter();
         LLVMInitializeNativeAsmParser();
         LLVMInitializeNativeTarget();

--- a/llvm/samples/llvm/Factorial.java
+++ b/llvm/samples/llvm/Factorial.java
@@ -60,7 +60,6 @@ public class Factorial {
 
     public static void main(String[] args) {
         // Stage 1: Initialize LLVM components
-//        LLVMInitializeCore(LLVMGetGlobalPassRegistry());
         LLVMLinkInMCJIT();
         LLVMInitializeNativeAsmPrinter();
         LLVMInitializeNativeAsmParser();
@@ -114,9 +113,6 @@ public class Factorial {
 
         // Stage 4: Create a pass pipeline using the legacy pass manager
         LLVMPassManagerRef pm = LLVMCreatePassManager();
-//        LLVMAddAggressiveInstCombinerPass(pm);
-//        LLVMAddNewGVNPass(pm);
-//        LLVMAddCFGSimplificationPass(pm);
         LLVMRunPassManager(pm, module);
         LLVMDumpModule(module);
 

--- a/llvm/samples/llvm/MCJIT.java
+++ b/llvm/samples/llvm/MCJIT.java
@@ -54,15 +54,13 @@ import static org.bytedeco.llvm.global.LLVM.*;
  * <p>
  * TODO(supergrecko): Replace with new Pass Manager for LLVM 13
  */
-public class Factorial {
-    // a 'char *' used to retrieve error messages from LLVM
+public class MCJIT {
+    // A 'char *' used to retrieve error messages from LLVM
     private static final BytePointer error = new BytePointer();
 
     public static void main(String[] args) {
         // Stage 1: Initialize LLVM components
-        LLVMLinkInMCJIT();
         LLVMInitializeNativeAsmPrinter();
-        LLVMInitializeNativeAsmParser();
         LLVMInitializeNativeTarget();
 
         // Stage 2: Build the factorial function.
@@ -105,7 +103,10 @@ public class Factorial {
         LLVMAddIncoming(phi, phiValues, phiBlocks, /* pairCount */ 2);
         LLVMBuildRet(builder, phi);
 
-        // Stage 3: Verify the module using LLVMVerifier
+        // Print generated LLVM-IR to console (optional)
+        LLVMDumpModule(module);
+
+        // Stage 3: Verify the module (optional; recommended)
         if (LLVMVerifyModule(module, LLVMPrintMessageAction, error) != 0) {
             LLVMDisposeMessage(error);
             return;
@@ -114,7 +115,6 @@ public class Factorial {
         // Stage 4: Create a pass pipeline using the legacy pass manager
         LLVMPassManagerRef pm = LLVMCreatePassManager();
         LLVMRunPassManager(pm, module);
-        LLVMDumpModule(module);
 
         // Stage 5: Execute the code using MCJIT
         LLVMExecutionEngineRef engine = new LLVMExecutionEngineRef();
@@ -128,8 +128,8 @@ public class Factorial {
         LLVMGenericValueRef argument = LLVMCreateGenericValueOfInt(i32Type, 10, /* signExtend */ 0);
         LLVMGenericValueRef result = LLVMRunFunction(engine, factorial, /* argumentCount */ 1, argument);
         System.out.println();
-        System.out.println("; Running factorial(10) with MCJIT...");
-        System.out.println("; Result: " + LLVMGenericValueToInt(result, /* signExtend */ 0));
+        System.out.println("Running factorial(10) with MCJIT...");
+        System.out.println("Result: " + LLVMGenericValueToInt(result, /* signExtend */ 0));
 
         // Stage 6: Dispose of the allocated resources
         LLVMDisposeExecutionEngine(engine);

--- a/llvm/samples/llvm/MCJIT.java
+++ b/llvm/samples/llvm/MCJIT.java
@@ -60,8 +60,8 @@ public class MCJIT {
 
     public static void main(String[] args) {
         // Stage 1: Initialize LLVM components
-        LLVMInitializeNativeAsmPrinter();
         LLVMInitializeNativeTarget();
+        LLVMInitializeNativeAsmPrinter();
 
         // Stage 2: Build the factorial function.
         LLVMContextRef context = LLVMContextCreate();

--- a/llvm/samples/llvm/OrcJit.java
+++ b/llvm/samples/llvm/OrcJit.java
@@ -26,7 +26,6 @@ import org.bytedeco.javacpp.LongPointer;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
 import org.bytedeco.libffi.ffi_cif;
-import org.bytedeco.llvm.global.LLVM;
 import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
 import org.bytedeco.llvm.LLVM.LLVMBuilderRef;
 import org.bytedeco.llvm.LLVM.LLVMContextRef;
@@ -98,7 +97,7 @@ public class OrcJit {
         // Stage 4: Execute using OrcJIT
         LLVMOrcLLJITRef jit = new LLVMOrcLLJITRef();
         LLVMOrcLLJITBuilderRef jitBuilder = LLVMOrcCreateLLJITBuilder();
-        LLVMErrorRef error = null;
+        LLVMErrorRef error;
         if ((error = LLVMOrcCreateLLJIT(jit, jitBuilder)) != null) {
             BytePointer errorMessage = LLVMGetErrorMessage(error);
             System.err.println("Failed to create LLJIT: " + errorMessage.getString());

--- a/llvm/samples/llvm/OrcJit.java
+++ b/llvm/samples/llvm/OrcJit.java
@@ -21,7 +21,6 @@
  */
 
 import org.bytedeco.javacpp.IntPointer;
-import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.LongPointer;
 import org.bytedeco.javacpp.Pointer;
@@ -60,7 +59,6 @@ public class OrcJit {
 
     public static void main(String[] args) {
         // Stage 1: Initialize LLVM components
-//        LLVMInitializeCore(LLVMGetGlobalPassRegistry());
         LLVMInitializeNativeTarget();
         LLVMInitializeNativeAsmPrinter();
 
@@ -93,7 +91,6 @@ public class OrcJit {
         // Stage 3: Execute using OrcJIT
         LLVMOrcLLJITRef jit = new LLVMOrcLLJITRef();
         LLVMOrcLLJITBuilderRef jitBuilder = LLVMOrcCreateLLJITBuilder();
-        Loader.loadGlobal(Loader.load(LLVM.class));
         if ((err = LLVMOrcCreateLLJIT(jit, jitBuilder)) != null) {
             BytePointer errorMessage = LLVMGetErrorMessage(err);
             System.err.println("Failed to create LLJIT: " + errorMessage.getString());

--- a/llvm/samples/llvm/OrcJit.java
+++ b/llvm/samples/llvm/OrcJit.java
@@ -22,6 +22,7 @@
 
 import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.javacpp.Loader;
+import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.LongPointer;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
@@ -94,22 +95,25 @@ public class OrcJit {
         LLVMOrcLLJITBuilderRef jitBuilder = LLVMOrcCreateLLJITBuilder();
         Loader.loadGlobal(Loader.load(LLVM.class));
         if ((err = LLVMOrcCreateLLJIT(jit, jitBuilder)) != null) {
-            System.err.println("Failed to create LLJIT: " + LLVMGetErrorMessage(err).getString());
-            LLVMConsumeError(err);
+            BytePointer errorMessage = LLVMGetErrorMessage(err);
+            System.err.println("Failed to create LLJIT: " + errorMessage.getString());
+            LLVMDisposeErrorMessage(errorMessage);
             return;
         }
 
         LLVMOrcJITDylibRef mainDylib = LLVMOrcLLJITGetMainJITDylib(jit);
         if ((err = LLVMOrcLLJITAddLLVMIRModule(jit, mainDylib, threadModule)) != null) {
-            System.err.println("Failed to add LLVM IR module: " + LLVMGetErrorMessage(err).getString());
-            LLVMConsumeError(err);
+            BytePointer errorMessage = LLVMGetErrorMessage(err);
+            System.err.println("Failed to add LLVM IR module: " + errorMessage.getString());
+            LLVMDisposeErrorMessage(errorMessage);
             return;
         }
 
         final LongPointer res = new LongPointer(1);
         if ((err = LLVMOrcLLJITLookup(jit, res, "sum")) != null) {
-            System.err.println("Failed to look up 'sum' symbol: " + LLVMGetErrorMessage(err).getString());
-            LLVMConsumeError(err);
+            BytePointer errorMessage = LLVMGetErrorMessage(err);
+            System.err.println("Failed to look up 'sum' symbol: " + errorMessage.getString());
+            LLVMDisposeErrorMessage(errorMessage);
             return;
         }
 

--- a/llvm/samples/llvm/pom.xml
+++ b/llvm/samples/llvm/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>samples</artifactId>
     <version>1.5.11-SNAPSHOT</version>
     <properties>
-        <exec.mainClass>Factorial</exec.mainClass>
+        <exec.mainClass>MCJIT</exec.mainClass>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
@@ -47,7 +47,7 @@
         <profile>
             <id>factorial</id>
             <properties>
-                <exec.mainClass>Factorial</exec.mainClass>
+                <exec.mainClass>MCJIT</exec.mainClass>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## Issue

The LLVM ORC example segfaults when freeing error messages using `LLVMConsumeError` because `LLVMGetErrorMessage` already consumes the error.

## Changes

- Fixed error handling
- Removed unnecessary initialization / function calls
- Renamed `Factorial` example to `MCJIT` to highlight the difference between `MCJIT` and `ORC`
- Added info that `ORC` is newer than `MCJIT` to the readme
- Improved readability
- Fixed typos

## Notes
- I tested all changes