### PR TITLE
Enable HDF5 build on aarch64 machine

### DIFF
--- a/hdf5/cppbuild.sh
+++ b/hdf5/cppbuild.sh
@@ -103,6 +103,10 @@ case $PLATFORM in
           ./configure --prefix=$INSTALL_PATH CC="gcc -m64" CXX="g++ -m64" --enable-cxx --enable-java
           make -j $MAKEJ
           make install-strip
+        elif [[ "$MACHINE_TYPE" =~ aarch64 ]]; then
+          ./configure --prefix=$INSTALL_PATH CC="gcc" CXX="g++" --enable-cxx --enable-java
+          make -j $MAKEJ
+          make install-strip
         else
           echo "Not native arm so assume cross compiling"
           patch -Np1 < ../../../hdf5-linux-arm64.patch || true


### PR DESCRIPTION
Additional platform check handling in `cppbuild.sh` for linux-arm64 machines to account for aarch64 as a possible machine type.

New code for the `"$MACHINE_TYPE" =~ aarch64` case executes same commands for arm64 machine type, but omitting `-m64` flags from g++ and gcc as they are unnecessary and throw errors on aarch64.