### PR TITLE
Use ARM runners for CPython and Numpy

### DIFF
--- a/.github/actions/deploy-ubuntu/action.yml
+++ b/.github/actions/deploy-ubuntu/action.yml
@@ -78,7 +78,9 @@ runs:
         source /etc/os-release
         export CODENAME=$UBUNTU_CODENAME
 
-        if [[ ! "$ARCH" == "amd64" ]]; then
+        # arm64 runners don't work with apt-spy2,
+        # the selected mirrors don't have arm64 binaries
+        if [[ ! "$ARCH" == "amd64" && ! "$ARCH" == "arm64" ]]; then
           # https://github.com/actions/runner-images/issues/675
           $SUDO gem install apt-spy2
           $SUDO apt-spy2 check

--- a/.github/actions/deploy-ubuntu/action.yml
+++ b/.github/actions/deploy-ubuntu/action.yml
@@ -20,12 +20,14 @@ runs:
         $SUDO rm -rf /usr/local/lib/android
         $SUDO rm -rf /usr/share/dotnet
 
-        # Allocate a swapfile on Linux as it's not enabled by default. Needed for pytorch and mkl.
-        $SUDO fallocate -l 4GB /swapfile
-        $SUDO chmod 600 /swapfile
-        $SUDO mkswap /swapfile
-        $SUDO swapon /swapfile || true
-
+        # fallocate fails on arm64 runners
+        if [[ ! "$CI_DEPLOY_PLATFORM" == "linux-arm64" ]]; then
+          # Allocate a swapfile on Linux as it's not enabled by default. Needed for pytorch and mkl.
+          $SUDO fallocate -l 4GB /swapfile
+          $SUDO chmod 600 /swapfile
+          $SUDO mkswap /swapfile
+          $SUDO swapon /swapfile || true
+        fi
         mkdir -p .ccache
         echo "max_size = 2.0G"                                                                        > .ccache/ccache.conf
         echo "hash_dir = false"                                                                      >> .ccache/ccache.conf

--- a/.github/workflows/cpython.yml
+++ b/.github/workflows/cpython.yml
@@ -21,10 +21,10 @@ jobs:
 #    runs-on: ubuntu-22.04
 #    steps:
 #      - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
-#  linux-arm64:
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
+ linux-arm64:
+   runs-on: ubuntu-22.04-arm
+   steps:
+     - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
 #  linux-ppc64le:
 #    runs-on: ubuntu-22.04
 #    steps:

--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -21,10 +21,10 @@ jobs:
 #    runs-on: ubuntu-22.04
 #    steps:
 #      - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
-#  linux-arm64:
-#    runs-on: ubuntu-22.04
-#    steps:
-#      - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
+ linux-arm64:
+   runs-on: ubuntu-22.04-arm
+   steps:
+     - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
 #  linux-ppc64le:
 #    runs-on: ubuntu-22.04
 #    steps:

--- a/cpython/cppbuild.sh
+++ b/cpython/cppbuild.sh
@@ -68,7 +68,12 @@ case $PLATFORM in
     linux-arm64)
         CFLAGS="-march=armv8-a+crypto -mcpu=cortex-a57+crypto"
         cd ../$OPENSSL
-        ./Configure $OS-$ARCH -fPIC no-shared --prefix=$INSTALL_PATH/host --libdir=lib
+        OPENSSL_PLATFORM=$OS-$ARCH
+        if [[ "$OPENSSL_PLATFORM" == "linux-arm64" ]]; then
+            # OpenSSL doesn't recognize arm64 as a valid architecture
+            OPENSSL_PLATFORM="linux-aarch64"
+        fi;
+        ./Configure $OPENSSL_PLATFORM -fPIC no-shared --prefix=$INSTALL_PATH/host --libdir=lib
         make -s -j $MAKEJ
         make install_sw
         make distclean

--- a/numpy/cppbuild.sh
+++ b/numpy/cppbuild.sh
@@ -85,6 +85,9 @@ fi
 export PYTHONPATH="$PYTHON_INSTALL_PATH"
 mkdir -p "$PYTHON_INSTALL_PATH"
 
+# Pip isn't installed by default, so make sure it is
+$PYTHON_BIN_PATH -m ensurepip
+
 TOOLS="setuptools==67.6.1 cython==3.0.10"
 if ! $PYTHON_BIN_PATH -m pip install --target=$PYTHON_LIB_PATH $TOOLS; then
     echo "extra_link_args = -lgfortran"           >> site.cfg
@@ -93,6 +96,8 @@ if ! $PYTHON_BIN_PATH -m pip install --target=$PYTHON_LIB_PATH $TOOLS; then
 
     # crossenv 1.4 for python 3.11+ support.
     # See https://github.com/bytedeco/javacpp-presets/issues/1381
+    # NOTE: Cross-compilation to arm may not work, it is recommended
+    # to compile on real hardware using e.g. Github Action's ARM runners
     "$CPYTHON_HOST_PATH/bin/python3.13" -m pip install --target="$CPYTHON_HOST_PATH/lib/python3.13/" crossenv==1.4 $TOOLS
     "$CPYTHON_HOST_PATH/bin/python3.13" -m crossenv "$PYTHON_BIN_PATH" crossenv
     source crossenv/bin/activate
@@ -108,8 +113,6 @@ case $PLATFORM in
         arm-linux-gnueabihf-strip $(find ../ -iname *.so)
         ;;
     linux-arm64)
-        rm -f meson.build pyproject.toml
-        mv pyproject.toml.setuppy pyproject.toml
         ATLAS=None CC="aarch64-linux-gnu-gcc -mabi=lp64" CFLAGS="-O2" "$PYTHON_BIN_PATH" -m pip install . --prefix $INSTALL_PATH
         aarch64-linux-gnu-strip $(find ../ -iname *.so)
         ;;


### PR DESCRIPTION
This PR enables ARM builds for CPython and Numpy by using the Github Actions ARM runners. It also makes minor changes to the `cppbuild.sh` scripts for both to fix compilation issues on ARM. For numpy, this entailed removing the workaround implemented in #1386.

### Note
I made the minimal changes necessary to fix ARM compilation. This means that the cpython build still essentially does cross-compilation to target ARM even when running on ARM hosts. It may be desirable to add a check for whether the target and host platforms match to improve build times.

The cpp build was verified to succeed on a Raspberry Pi 4, I have not yet verified full end-to-end success via maven due to a missing dependency on the pi.