### PR TITLE
MKL 2025.0 build for JavaCPP 1.5.12

### DIFF
--- a/mkl/platform/pom.xml
+++ b/mkl/platform/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.bytedeco</groupId>
     <artifactId>javacpp-presets</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/mkl/platform/redist/pom.xml
+++ b/mkl/platform/redist/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.bytedeco</groupId>
     <artifactId>javacpp-presets</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/mkl/pom.xml
+++ b/mkl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.bytedeco</groupId>
     <artifactId>javacpp-presets</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12-SNAPSHOT</version>
   </parent>
 
   <groupId>org.bytedeco</groupId>


### PR DESCRIPTION
I've just updated the MKL build for 2025.0 (the same as it was in JavaCPP 1.5.11) to fit into the rest of javacpp-presets which are nearing the 1.5.12 release. 

I did a local build on my Arch Linux machine, and it went without any problems. (The Github Actions failed quickly due to, it was reported, a "outdated Ubuntu version"). So I hope it's a matter of updating the setup to a more recent stack (I don't know where to change this).

Windows build in GitHub Actions succeeded without a hitch.

I hope this could be included in JavaCPP 1.5.12, since MKL is not just a very featureful BLAS/LAPACK implementation, but also comes with DSP, sparse matrices, statistics, and load of other operations useful in number crunching, which are missing from the alternatives such as OpenBLAS.