### PR TITLE
Add `linux-arm64` platform support to ONNX build and CI without cross-compilation

### DIFF
--- a/.github/workflows/onnx.yml
+++ b/.github/workflows/onnx.yml
@@ -17,6 +17,10 @@ env:
   CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
   STAGING_REPOSITORY: ${{ secrets.STAGING_REPOSITORY }}
 jobs:
+  linux-arm64:
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: bytedeco/javacpp-presets/.github/actions/deploy-ubuntu@actions
   linux-x86_64:
     runs-on: ubuntu-22.04
     steps:

--- a/onnx/platform/pom.xml
+++ b/onnx/platform/pom.xml
@@ -40,6 +40,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>${javacpp.moduleId}</artifactId>
       <version>${project.version}</version>
+      <classifier>${javacpp.platform.linux-arm64}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${javacpp.moduleId}</artifactId>
+      <version>${project.version}</version>
       <classifier>${javacpp.platform.linux-x86_64}</classifier>
     </dependency>
     <dependency>
@@ -72,7 +78,7 @@
             <configuration>
               <archive>
                 <manifestEntries>
-                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-arm64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
+                  <Class-Path>${javacpp.moduleId}.jar ${javacpp.moduleId}-linux-arm64.jar ${javacpp.moduleId}-linux-x86_64.jar ${javacpp.moduleId}-macosx-arm64.jar ${javacpp.moduleId}-macosx-x86_64.jar ${javacpp.moduleId}-windows-x86_64.jar</Class-Path>
                 </manifestEntries>
               </archive>
             </configuration>
@@ -117,6 +123,7 @@
                   <file>${project.build.directory}/${project.artifactId}.jar</file>
                   <moduleInfoSource>
                     module org.bytedeco.${javacpp.moduleId}.platform {
+                      requires static org.bytedeco.${javacpp.moduleId}.linux.arm64;
                       requires static org.bytedeco.${javacpp.moduleId}.linux.x86_64;
                       requires static org.bytedeco.${javacpp.moduleId}.macosx.arm64;
                       requires static org.bytedeco.${javacpp.moduleId}.macosx.x86_64;

--- a/pom.xml
+++ b/pom.xml
@@ -1219,6 +1219,7 @@
         <module>tensorflow-lite</module>
         <module>tensorrt</module>
         <module>depthai</module>
+        <module>onnx</module>
         <module>onnxruntime</module>
         <module>cpu_features</module>
         <module>systems</module>


### PR DESCRIPTION
Related #1697