### PR TITLE
Fix newer C++ compiler errors by including <cstdint> in optimizer_api.h

### DIFF
--- a/onnxruntime/onnxruntime.patch
+++ b/onnxruntime/onnxruntime.patch
@@ -387,3 +387,14 @@ index 215ad77335..0584b0533c 100644
      parser.add_argument(
          "--arm64ec",
          action="store_true",
+diff --git a/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h b/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h
+--- a/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h
++++ b/onnxruntime/core/optimizer/transpose_optimization/optimizer_api.h
+@@ -11,6 +11,7 @@
+ #include <unordered_map>
+ #include <unordered_set>
+ #include <vector>
++#include <cstdint>
+ 
+ namespace onnx_transpose_optimization {
+ namespace api {


### PR DESCRIPTION
The current build (1.22.2) of onnxruntime fails with newer compilers. This is a problem with upstream too, not just javacpp). In upstream, this is solved by adding #include <cstdint> in optimizer.h. However, that fix only made it to the 1.23 release, and is not present in 1.22.2.