### PR TITLE
[PyTorch] Uses PointerScope to fix native memory leaks in AbstractTensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix memory leak in `Tensor` factory methods `create()`, `createBuffer()`, and `createIndexer()` for PyTorch ([pull #1722](https://github.com/bytedeco/javacpp-presets/pull/1722))
  * Rename `gloo` and `nccl` modules of PyTorch to `torch_gloo` and `torch_nccl` to avoid conflicts
  * Upgrade to NDK r29 for Android builds on GitHub Actions ([issue #1670](https://github.com/bytedeco/javacpp-presets/issues/1670))
  * Enable distributed package using NCCL in presets for PyTorch ([issue #1402](https://github.com/bytedeco/javacpp-presets/issues/1402))

--- a/pytorch/src/main/java/org/bytedeco/pytorch/AbstractTensor.java
+++ b/pytorch/src/main/java/org/bytedeco/pytorch/AbstractTensor.java
@@ -44,10 +44,12 @@ public abstract class AbstractTensor extends Pointer implements Indexable {
     public static Tensor create(boolean... data) { return create(data, data.length); }
 
     public static Tensor create(byte[] data, boolean signed, long... shape) {
-        Tensor t = empty(shape, new TensorOptions(signed ? ScalarType.Char : ScalarType.Byte), null);
-        ByteBuffer b = t.createBuffer();
-        b.put(data);
-        return t;
+        try (PointerScope scope = new PointerScope(TensorOptions.class, Device.class)) {
+            Tensor t = empty(shape, new TensorOptions(signed ? ScalarType.Char : ScalarType.Byte), null);
+            ByteBuffer b = t.createBuffer();
+            b.put(data);
+            return t;
+        }
     }
     public static Tensor create(byte[]    data, long... shape) { return create(data, false, shape); }
     public static Tensor create(short[]   data, long... shape) { Tensor t = empty(shape, new TensorOptions(ScalarType.Short), null);   ShortIndexer i = t.createIndexer(); i.put(0, data); return t; }
@@ -98,42 +100,24 @@ public abstract class AbstractTensor extends Pointer implements Indexable {
             Pointer ptr = data_ptr();
             long size = nbytes();
             switch (dtype) {
-                case Byte:
-                    return (B) new BytePointer(ptr).position(index).capacity(size).asBuffer();
-                case Char:
-                    return (B) new BytePointer(ptr).position(index).capacity(size).asBuffer();
-                case Short:
-                    return (B) new ShortPointer(ptr).position(index).capacity(size / 2).asBuffer();
-                case Int:
-                    return (B) new IntPointer(ptr).position(index).capacity(size / 4).asBuffer();
-                case Long:
-                    return (B) new LongPointer(ptr).position(index).capacity(size / 8).asBuffer();
-                case Half:
-                    return (B) new ShortPointer(ptr).position(index).capacity(size / 2).asBuffer();
-                case Float:
-                    return (B) new FloatPointer(ptr).position(index).capacity(size / 4).asBuffer();
-                case Double:
-                    return (B) new DoublePointer(ptr).position(index).capacity(size / 8).asBuffer();
-                case ComplexHalf:
-                    return (B) new ShortPointer(ptr).position(index * 2).capacity(size / 2).asBuffer();
-                case ComplexFloat:
-                    return (B) new FloatPointer(ptr).position(index * 2).capacity(size / 4).asBuffer();
-                case ComplexDouble:
-                    return (B) new DoublePointer(ptr).position(index * 2).capacity(size / 8).asBuffer();
-                case Bool:
-                    return (B) new BytePointer(ptr).position(index).capacity(size).asBuffer();
-                case QInt8:
-                    return (B) new BytePointer(ptr).position(index).capacity(size).asBuffer();
-                case QUInt8:
-                    return (B) new BytePointer(ptr).position(index).capacity(size).asBuffer();
-                case QInt32:
-                    return (B) new IntPointer(ptr).position(index).capacity(size / 4).asBuffer();
-                case BFloat16:
-                    return (B) new ShortPointer(ptr).position(index).capacity(size / 2).asBuffer();
-                case QUInt4x2:
-                    return (B) new BytePointer(ptr).position(index / 2).capacity(size).asBuffer();
-                default:
-                    throw new UnsupportedOperationException("Data type not supported: " + dtype);
+                case Byte:   return (B)new BytePointer(ptr).position(index).capacity(size).asBuffer();
+                case Char:   return (B)new BytePointer(ptr).position(index).capacity(size).asBuffer();
+                case Short:  return (B)new ShortPointer(ptr).position(index).capacity(size/2).asBuffer();
+                case Int:    return (B)new IntPointer(ptr).position(index).capacity(size/4).asBuffer();
+                case Long:   return (B)new LongPointer(ptr).position(index).capacity(size/8).asBuffer();
+                case Half:   return (B)new ShortPointer(ptr).position(index).capacity(size/2).asBuffer();
+                case Float:  return (B)new FloatPointer(ptr).position(index).capacity(size/4).asBuffer();
+                case Double: return (B)new DoublePointer(ptr).position(index).capacity(size/8).asBuffer();
+                case ComplexHalf:   return (B)new ShortPointer(ptr).position(index*2).capacity(size/2).asBuffer();
+                case ComplexFloat:  return (B)new FloatPointer(ptr).position(index*2).capacity(size/4).asBuffer();
+                case ComplexDouble: return (B)new DoublePointer(ptr).position(index*2).capacity(size/8).asBuffer();
+                case Bool:   return (B)new BytePointer(ptr).position(index).capacity(size).asBuffer();
+                case QInt8:  return (B)new BytePointer(ptr).position(index).capacity(size).asBuffer();
+                case QUInt8: return (B)new BytePointer(ptr).position(index).capacity(size).asBuffer();
+                case QInt32: return (B)new IntPointer(ptr).position(index).capacity(size/4).asBuffer();
+                case BFloat16: return (B)new ShortPointer(ptr).position(index).capacity(size/2).asBuffer();
+                case QUInt4x2: return (B)new BytePointer(ptr).position(index/2).capacity(size).asBuffer();
+                default: throw new UnsupportedOperationException("Data type not supported: " + dtype);
             }
         }
     }
@@ -154,10 +138,10 @@ public abstract class AbstractTensor extends Pointer implements Indexable {
             ScalarType dtype = scalar_type().intern();
             Pointer ptr = data_ptr();
             long size = nbytes();
-            int dims = (int) ndimension();
+            int dims = (int)ndimension();
             boolean complex = dtype == ScalarType.ComplexHalf
-                    || dtype == ScalarType.ComplexFloat
-                    || dtype == ScalarType.ComplexDouble;
+                           || dtype == ScalarType.ComplexFloat
+                           || dtype == ScalarType.ComplexDouble;
             boolean scalar = dims == 0;
             dims = (complex ? 1 : 0) + (scalar ? 1 : dims);
             long[] sizes = new long[dims];
@@ -169,42 +153,24 @@ public abstract class AbstractTensor extends Pointer implements Indexable {
                 strides[i] = scalar ? 1 : stride(i);
             }
             switch (dtype) {
-                case Byte:
-                    return (I) UByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
-                case Char:
-                    return (I) ByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
-                case Short:
-                    return (I) ShortIndexer.create(new ShortPointer(ptr).capacity(size / 2), sizes, strides, direct).indexable(this);
-                case Int:
-                    return (I) IntIndexer.create(new IntPointer(ptr).capacity(size / 4), sizes, strides, direct).indexable(this);
-                case Long:
-                    return (I) LongIndexer.create(new LongPointer(ptr).capacity(size / 8), sizes, strides, direct).indexable(this);
-                case Half:
-                    return (I) HalfIndexer.create(new ShortPointer(ptr).capacity(size / 2), sizes, strides, direct).indexable(this);
-                case Float:
-                    return (I) FloatIndexer.create(new FloatPointer(ptr).capacity(size / 4), sizes, strides, direct).indexable(this);
-                case Double:
-                    return (I) DoubleIndexer.create(new DoublePointer(ptr).capacity(size / 8), sizes, strides, direct).indexable(this);
-                case ComplexHalf:
-                    return (I) HalfIndexer.create(new ShortPointer(ptr).capacity(size / 2), sizes, strides, direct).indexable(this);
-                case ComplexFloat:
-                    return (I) FloatIndexer.create(new FloatPointer(ptr).capacity(size / 4), sizes, strides, direct).indexable(this);
-                case ComplexDouble:
-                    return (I) DoubleIndexer.create(new DoublePointer(ptr).capacity(size / 8), sizes, strides, direct).indexable(this);
-                case Bool:
-                    return (I) BooleanIndexer.create(new BooleanPointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
-                case QInt8:
-                    return (I) ByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
-                case QUInt8:
-                    return (I) UByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
-                case QInt32:
-                    return (I) IntIndexer.create(new IntPointer(ptr).capacity(size / 4), sizes, strides, direct).indexable(this);
-                case BFloat16:
-                    return (I) Bfloat16Indexer.create(new ShortPointer(ptr).capacity(size / 2), sizes, strides, direct).indexable(this);
-                case QUInt4x2:
-                    return (I) UByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
-                default:
-                    throw new UnsupportedOperationException("Data type not supported: " + dtype);
+                case Byte:   return (I)UByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
+                case Char:   return (I)ByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
+                case Short:  return (I)ShortIndexer.create(new ShortPointer(ptr).capacity(size/2), sizes, strides, direct).indexable(this);
+                case Int:    return (I)IntIndexer.create(new IntPointer(ptr).capacity(size/4), sizes, strides, direct).indexable(this);
+                case Long:   return (I)LongIndexer.create(new LongPointer(ptr).capacity(size/8), sizes, strides, direct).indexable(this);
+                case Half:   return (I)HalfIndexer.create(new ShortPointer(ptr).capacity(size/2), sizes, strides, direct).indexable(this);
+                case Float:  return (I)FloatIndexer.create(new FloatPointer(ptr).capacity(size/4), sizes, strides, direct).indexable(this);
+                case Double: return (I)DoubleIndexer.create(new DoublePointer(ptr).capacity(size/8), sizes, strides, direct).indexable(this);
+                case ComplexHalf:   return (I)HalfIndexer.create(new ShortPointer(ptr).capacity(size/2), sizes, strides, direct).indexable(this);
+                case ComplexFloat:  return (I)FloatIndexer.create(new FloatPointer(ptr).capacity(size/4), sizes, strides, direct).indexable(this);
+                case ComplexDouble: return (I)DoubleIndexer.create(new DoublePointer(ptr).capacity(size/8), sizes, strides, direct).indexable(this);
+                case Bool:   return (I)BooleanIndexer.create(new BooleanPointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
+                case QInt8:  return (I)ByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
+                case QUInt8: return (I)UByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
+                case QInt32: return (I)IntIndexer.create(new IntPointer(ptr).capacity(size/4), sizes, strides, direct).indexable(this);
+                case BFloat16: return (I)Bfloat16Indexer.create(new ShortPointer(ptr).capacity(size/2), sizes, strides, direct).indexable(this);
+                case QUInt4x2: return (I)UByteIndexer.create(new BytePointer(ptr).capacity(size), sizes, strides, direct).indexable(this);
+                default: throw new UnsupportedOperationException("Data type not supported: " + dtype);
             }
         }
     }


### PR DESCRIPTION
In the `createBuffer()` and `createIndexer()` methods of `AbstractTensor`, objects of type `TensorOptions` and`Device` were being created but never closed. Each allocates a small amount of native memory, so this was causing a memory leak when `tensor.createBuffer()` or `AbstractTensor.create()`.

The fix is simply to wrap the methods in an appropriate `PointerScope` so that the offending objects are automatically closed when the method returns.

This resolves issue https://github.com/bytedeco/javacpp-presets/issues/1721