### PR TITLE
Upgrade VulkanSDK to 1.4.313.0

### DIFF
--- a/.github/actions/deploy-macosx/action.yml
+++ b/.github/actions/deploy-macosx/action.yml
@@ -64,9 +64,9 @@ runs:
 
         # Install vulkan sdk
         echo Installing Vulkan SDK
-        curl -LO https://sdk.lunarg.com/sdk/download/1.3.280.1/mac/vulkansdk-macos-1.3.280.1.dmg
-        MOUNT_PATH=$(hdiutil mount vulkansdk-macos-1.3.280.1.dmg | tail -n1 | awk '{print $3}')
-        sudo "${MOUNT_PATH}/InstallVulkan.app/Contents/MacOS/InstallVulkan" --root ~/VulkanSDK/1.3.280.1 --accept-licenses --default-answer --confirm-command install com.lunarg.vulkan.core com.lunarg.vulkan.usr com.lunarg.vulkan.sdl2 com.lunarg.vulkan.glm com.lunarg.vulkan.volk com.lunarg.vulkan.vma
+        curl -LO https://sdk.lunarg.com/sdk/download/1.4.313.1/mac/vulkansdk-macos-1.4.313.1.zip
+        unzip vulkansdk-macos-1.4.313.1.zip
+        sudo ./vulkansdk-macOS-1.4.313.1.app/Contents/MacOS/vulkansdk-macOS-1.4.313.1 --root ~/VulkanSDK/1.4.313.1 --accept-licenses --default-answer --confirm-command install com.lunarg.vulkan.core com.lunarg.vulkan.usr com.lunarg.vulkan.sdl2 com.lunarg.vulkan.glm com.lunarg.vulkan.volk com.lunarg.vulkan.vma
 
         if [[ -n ${CI_DEPLOY_NEED_BAZEL:-} ]]; then
           echo Installing Bazel

--- a/.github/actions/deploy-ubuntu/action.yml
+++ b/.github/actions/deploy-ubuntu/action.yml
@@ -147,11 +147,11 @@ runs:
         echo Installing Vulkan-SDK
         if [[ "$CODENAME" == "jammy" ]]; then
           curl -s https://packages.lunarg.com/lunarg-signing-key-pub.asc | $SUDO tee /etc/apt/trusted.gpg.d/lunarg.asc >/dev/null
-          $SUDO curl -s -o /etc/apt/sources.list.d/lunarg-vulkan-1.3.280-jammy.list https://packages.lunarg.com/vulkan/1.3.280/lunarg-vulkan-1.3.280-jammy.list
+          $SUDO curl -s -o /etc/apt/sources.list.d/lunarg-vulkan-1.4.313-jammy.list https://packages.lunarg.com/vulkan/1.4.313/lunarg-vulkan-1.4.313-jammy.list
           $SUDO apt-get update && $SUDO apt-get install -y libvulkan1 libvulkan-dev vulkan-sdk && $SUDO apt-get clean
         elif [[ "$CODENAME" == "focal" ]]; then
           curl -s https://packages.lunarg.com/lunarg-signing-key-pub.asc | $SUDO apt-key add -
-          $SUDO curl -s -o /etc/apt/sources.list.d/lunarg-vulkan-1.3.280-focal.list https://packages.lunarg.com/vulkan/1.3.280/lunarg-vulkan-1.3.280-focal.list
+          $SUDO curl -s -o /etc/apt/sources.list.d/lunarg-vulkan-1.4.313-focal.list https://packages.lunarg.com/vulkan/1.4.313/lunarg-vulkan-1.4.313-focal.list
           $SUDO apt-get update && $SUDO apt-get install -y libvulkan1 libvulkan-dev vulkan-sdk && $SUDO apt-get clean
         fi
 

--- a/.github/actions/deploy-windows/action.yml
+++ b/.github/actions/deploy-windows/action.yml
@@ -104,8 +104,8 @@ runs:
           curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-tools-git-12.0.0.r81.g90abf784a-1-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-winpthreads-git-12.0.0.r81.g90abf784a-1-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-winstorecompat-git-12.0.0.r81.g90abf784a-1-any.pkg.tar.zst
-          curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-vulkan-headers-1.3.296.0-1-any.pkg.tar.zst
-          curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-vulkan-loader-1.3.296.0-1-any.pkg.tar.zst
+          curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-vulkan-headers-1.4.313.0-1-any.pkg.tar.zst
+          curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-vulkan-loader-1.4.313.0-1-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/i686/mingw-w64-i686-SDL2-2.30.12-1-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-14.2.0-3-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-14.2.0-3-any.pkg.tar.zst
@@ -124,8 +124,8 @@ runs:
           curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-tools-git-12.0.0.r81.g90abf784a-1-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-winpthreads-git-12.0.0.r81.g90abf784a-1-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-winstorecompat-git-12.0.0.r81.g90abf784a-1-any.pkg.tar.zst
-          curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-vulkan-headers-1.3.296.0-1-any.pkg.tar.zst
-          curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-vulkan-loader-1.3.296.0-1-any.pkg.tar.zst
+          curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-vulkan-headers-1.4.313.0-1-any.pkg.tar.zst
+          curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-vulkan-loader-1.4.313.0-1-any.pkg.tar.zst
           curl -LO http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.30.12-1-any.pkg.tar.zst
           bash -c "pacman -Rc --noconfirm mingw-w64-x86_64-gdb-multiarch mingw-w64-x86_64-gdb mingw-w64-x86_64-libb2 mingw-w64-x86_64-python"
           bash -c "pacman -U --noconfirm *.pkg.tar.zst"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  * Add new `SampleOnnxMNIST` in samples for TensorRT ([pull #1742](https://github.com/bytedeco/javacpp-presets/pull/1742))
  * Fix loading issues with `libomp.dylib` and `libiomp5.dylib` for DNNL and PyTorch on Mac
  * Include `model_package_loader.h` header file in presets for PyTorch ([issue #1729](https://github.com/bytedeco/javacpp-presets/issues/1729))
- * Upgrade presets for FFmpeg 8.1, OpenBLAS 0.3.32, CUDA 13.2.1, cuDNN 9.21.1.3, NCCL 2.30.4, nvCOMP 5.2.0.10, CPython 3.14.4, NumPy 2.4.4, SciPy 1.17.1, LLVM 22.1.1, PyTorch 2.11.0, TensorFlow Lite 2.21.0, TensorRT 10.16.1.11, Triton Inference Server 2.68.0, ONNX 1.21.0, ONNX Runtime 1.25.1 ([pull #1753](https://github.com/bytedeco/javacpp-presets/pull/1753)), and their dependencies
+ * Upgrade presets for FFmpeg 8.1, OpenBLAS 0.3.32, CUDA 13.2.1, cuDNN 9.21.1.3, NCCL 2.30.4, nvCOMP 5.2.0.10, CPython 3.14.4, NumPy 2.4.4, SciPy 1.17.1, LLVM 22.1.1, PyTorch 2.11.0, TensorFlow Lite 2.21.0, TensorRT 10.16.1.11, Triton Inference Server 2.68.0, ONNX 1.21.0, ONNX Runtime 1.25.1 ([pull #1753](https://github.com/bytedeco/javacpp-presets/pull/1753)), VulkanSDK 1.4.313.0 ([pull #1768](https://github.com/bytedeco/javacpp-presets/pull/1768)), and their dependencies
  * Compile classes with `parameters` bumping minimum requirements to Java SE 8 and Android 7.0 ([issue #1739](https://github.com/bytedeco/javacpp-presets/issues/1739))
 
 ### February 22, 2026 version 1.5.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  * Add new `SampleOnnxMNIST` in samples for TensorRT ([pull #1742](https://github.com/bytedeco/javacpp-presets/pull/1742))
  * Fix loading issues with `libomp.dylib` and `libiomp5.dylib` for DNNL and PyTorch on Mac
  * Include `model_package_loader.h` header file in presets for PyTorch ([issue #1729](https://github.com/bytedeco/javacpp-presets/issues/1729))
- * Upgrade presets for FFmpeg 8.1, OpenBLAS 0.3.32, CUDA 13.2.1, cuDNN 9.21.1.3, NCCL 2.30.4, nvCOMP 5.2.0.10, CPython 3.14.4, NumPy 2.4.4, SciPy 1.17.1, LLVM 22.1.1, PyTorch 2.11.0, TensorFlow Lite 2.21.0, TensorRT 10.16.1.11, Triton Inference Server 2.68.0, ONNX 1.21.0, ONNX Runtime 1.25.1 ([pull #1753](https://github.com/bytedeco/javacpp-presets/pull/1753)), VulkanSDK 1.4.313.0 ([pull #1768](https://github.com/bytedeco/javacpp-presets/pull/1768)), and their dependencies
+ * Upgrade presets for FFmpeg 8.1, OpenBLAS 0.3.32, CUDA 13.2.1, cuDNN 9.21.1.3, NCCL 2.30.4, nvCOMP 5.2.0.10, CPython 3.14.4, NumPy 2.4.4, SciPy 1.17.1, LLVM 22.1.1, PyTorch 2.11.0, TensorFlow Lite 2.21.0, TensorRT 10.16.1.11, Triton Inference Server 2.68.0, ONNX 1.21.0, ONNX Runtime 1.25.1 ([pull #1753](https://github.com/bytedeco/javacpp-presets/pull/1753)), and their dependencies
  * Compile classes with `parameters` bumping minimum requirements to Java SE 8 and Android 7.0 ([issue #1739](https://github.com/bytedeco/javacpp-presets/issues/1739))
 
 ### February 22, 2026 version 1.5.13


### PR DESCRIPTION
Fix CI fail in https://github.com/bytedeco/javacpp-presets/actions/runs/25850340240/job/75955077905

[Vulkan SDK 1.3.280.1](https://[sdk.lunarg.com](https://sdk.lunarg.com/sdk/download/1.3.280.1/mac/vulkansdk-macos-1.3.280.1.dmg)/sdk/download/1.3.280.1/mac/vulkansdk-macos-1.3.280.1.dmg) is currently unavailable