### PR TITLE
Fix ONNX Runtime OpenVINO model compilation

### DIFF
--- a/onnxruntime/onnxruntime-openvino.patch
+++ b/onnxruntime/onnxruntime-openvino.patch
@@ -194,3 +194,19 @@ index dd43f856e0..6a34827b1a 100644
 +#elif __GNUC__
 +#pragma GCC diagnostic pop
 +#endif
+diff --git a/onnxruntime/core/providers/openvino/backends/basic_backend.cc b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+index b39db2be12..8cbded29ce 100644
+--- a/onnxruntime/core/providers/openvino/backends/basic_backend.cc
++++ b/onnxruntime/core/providers/openvino/backends/basic_backend.cc
+@@ -89,7 +89,10 @@ BasicBackend::BasicBackend(std::unique_ptr<onnx::ModelProto>& model_proto,
+ #if defined(OPENVINO_DISABLE_NPU_FALLBACK)
+     eligible_for_cpu_fallback = false;
+ #endif
+-    auto auto_unified_compile = (hw_target.find("AUTO") == std::string::npos);
++    // OpenVINO 2026.2 cannot compile an ONNX model directly from its serialized
++    // string. Use the frontend's read/convert path for all device types instead.
++    // This is already the path used by the AUTO device and other special cases.
++    auto auto_unified_compile = false;
+
+     // Unified compile is efficient with cahce_dir cached model loading that bypass Read Model
+     // Does not support model with exteral weights, dynamic input shape, Epctx onnx cached model,


### PR DESCRIPTION
### Motivation
OpenVINO 2026.2 can fail when compiling ONNX models directly from their serialized string, causing the OpenVINO execution provider to throw during initialization; the frontend read/convert path (used by the AUTO device) avoids this failure.

### Description
Force auto_unified_compile = false in the OpenVINO BasicBackend (via the OpenVINO integration patch) so all device types use the frontend read/convert path instead of the failing unified serialized-ONNX compile path.

### Testing
Reproduced the reported CPU failure using published 1.28.0-*-SNAPSHOT artifacts with OpenVINOExecutionProviderSample, which failed as described.
Verified the same sample succeeds with AUTO (frontend read/convert path) and that it succeeds after applying the change.
Verified the patch applies cleanly to the ONNX Runtime v1.28.0 source with git apply --recount --check, and ran bash -n onnxruntime/cppbuild.sh and git diff --check, all of which completed without errors.

### Note
This ideally needs to be addressed by an upstream fix, but this should work in the interim. Fixes https://github.com/bytedeco/javacpp-presets/issues/1788